### PR TITLE
Add shim logger cleanup time

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following list of arguments apply to all of the shim logger binaries in this
 | max-buffer-size | No | Only supported in `non-blocking` mode. Set to `1m` (1MiB) by default. Example values: `200`, `4k`, `1m` etc. |
 | uid | No | Set a custom uid for the shim logger process. `0` is not supported. |
 | gid | No | Set a custom gid for the shim logger process. `0` is not supported. |
+| cleanup-time | No | Set a custom time for the shim logger process clean up itself. Set to `5s` (5 seconds) by default. Note the maximum supported value is 12 seconds, since containerd shim sets shim logger cleanup timeout value as 12 seconds. See [reference](https://github.com/containerd/containerd/commit/0dc7c8595627e38ca2b83d17a062b51f384c2025). |
 
 
 ### Additional log driver options

--- a/init.go
+++ b/init.go
@@ -42,6 +42,9 @@ const (
 	// UID/GID option
 	uidKey = "uid"
 	gidKey = "gid"
+
+	// cleanup time option
+	cleanupTimeKey = "cleanup-time"
 )
 
 // initCommonLogOpts initialize common options that get used by any log drivers
@@ -63,6 +66,9 @@ func initCommonLogOpts() {
 	// set uid/gid option
 	pflag.Int(uidKey, -1, "Customized uid for all the goroutines in shim logger process")
 	pflag.Int(gidKey, -1, "Customized gid for all the goroutines in shim logger process")
+
+	// cleanup time option
+	pflag.String(cleanupTimeKey, "5s", "Cleanup time after pipes are closed, default to 5 seconds")
 }
 
 // initAWSLogsOpts initialize awslogs driver specified options

--- a/logger/awslogs/logger.go
+++ b/logger/awslogs/logger.go
@@ -94,7 +94,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 
 	// Start awslogs driver
 	debug.SendEventsToJournal(logger.DaemonName, "Starting awslogs driver", journal.PriInfo)
-	err = l.Start(la.globalArgs.UID, la.globalArgs.GID, ready)
+	err = l.Start(la.globalArgs.UID, la.globalArgs.GID, la.globalArgs.CleanupTime, ready)
 	if err != nil {
 		return errors.Wrap(err, "failed to start awslogs driver")
 	}

--- a/logger/common_test.go
+++ b/logger/common_test.go
@@ -42,6 +42,7 @@ var (
 	dummyLogMsg            = []byte("test log message")
 	dummySource            = "stdout"
 	dummyTime              = time.Date(2020, time.January, 14, 01, 59, 0, 0, time.UTC)
+	dummyCleanupTime       = time.Duration(2 * time.Second)
 	logDestinationFileName string
 )
 
@@ -148,7 +149,7 @@ func TestSendLogs(t *testing.T) {
 	f, err := os.Open(tmpIOSource.Name())
 	require.NoError(t, err)
 	defer f.Close()
-	go l.sendLogs(f, &wg, dummySource, -1, -1)
+	go l.sendLogs(f, &wg, dummySource, -1, -1, &dummyCleanupTime)
 	wg.Wait()
 
 	// Make sure the new scanned log message has been written to the tmp file by sendLogs

--- a/logger/fluentd/logger.go
+++ b/logger/fluentd/logger.go
@@ -86,7 +86,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 
 	// Start fluentd driver
 	debug.SendEventsToJournal(logger.DaemonName, "Starting fluentd driver", journal.PriInfo)
-	err = l.Start(la.globalArgs.UID, la.globalArgs.GID, ready)
+	err = l.Start(la.globalArgs.UID, la.globalArgs.GID, la.globalArgs.CleanupTime, ready)
 	if err != nil {
 		return errors.Wrap(err, "failed to start fluentd driver")
 	}

--- a/logger/splunk/logger.go
+++ b/logger/splunk/logger.go
@@ -116,7 +116,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 
 	// Start splunk log driver
 	debug.SendEventsToJournal(logger.DaemonName, "Starting splunk driver", journal.PriInfo)
-	err = l.Start(la.globalArgs.UID, la.globalArgs.GID, ready)
+	err = l.Start(la.globalArgs.UID, la.globalArgs.GID, la.globalArgs.CleanupTime, ready)
 	if err != nil {
 		return errors.Wrap(err, "failed to start splunk driver")
 	}


### PR DESCRIPTION
*Description of changes:*
Add cleanup-time parameter for cleaning up resources like flushing
last few log events to destination after pipes are closed. Default
to 5 seconds and maximum supported value is 12.

This commit also adds unit tests to cover different cleanup time
cases.

`make test` and `make lint` all passed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
