### PR TITLE
Rework shim logger debugging log messages

### DIFF
--- a/args.go
+++ b/args.go
@@ -64,7 +64,7 @@ func getGlobalArgs() (*logger.GlobalArgs, error) {
 		debug.SendEventsToJournal(logger.DaemonName,
 			fmt.Sprintf("Container ID: %s, Container Name: %s, log driver: %s, mode: %s, max buffer size: %d",
 				containerID, containerName, logDriver, mode, maxBufferSize),
-			journal.PriDebug)
+			journal.PriDebug, 0)
 	}
 
 	args := &logger.GlobalArgs{

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.2
 	github.com/tinylib/msgp v1.1.1 // indirect
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/grpc v1.26.0 // indirect
 	gotest.tools v2.2.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,7 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/logger/awslogs/logger.go
+++ b/logger/awslogs/logger.go
@@ -66,6 +66,8 @@ func InitLogger(globalArgs *logger.GlobalArgs, awslogsArgs *Args) *LoggerArgs {
 
 // RunLogDriver initiates an awslogs driver and starts driving container logs to cloudwatch
 func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, ready func() error) error {
+	defer debug.DeferFuncForRunLogDriver()
+
 	loggerConfig := getAWSLogsConfig(la.args)
 	info := logger.NewInfo(
 		la.globalArgs.ContainerID,
@@ -74,7 +76,8 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 	)
 	stream, err := dockerawslogs.New(*info)
 	if err != nil {
-		return errors.Wrap(err, "unable to create stream")
+		debug.LoggerErr = errors.Wrap(err, "unable to create stream")
+		return debug.LoggerErr
 	}
 
 	l, err := logger.NewLogger(
@@ -84,21 +87,28 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 		logger.WithStream(stream),
 	)
 	if err != nil {
-		return errors.Wrap(err, "unable to create awslogs driver")
+		debug.LoggerErr = errors.Wrap(err, "unable to create awslogs driver")
+		return debug.LoggerErr
 	}
 
 	if la.globalArgs.Mode == logger.NonBlockingMode {
-		debug.SendEventsToJournal(logger.DaemonName, "Starting non-blocking mode driver", journal.PriInfo)
+		debug.SendEventsToJournal(logger.DaemonName, "Starting non-blocking mode driver", journal.PriInfo, 0)
 		l = logger.NewBufferedLogger(l, la.globalArgs.MaxBufferSize)
 	}
 
 	// Start awslogs driver
-	debug.SendEventsToJournal(logger.DaemonName, "Starting awslogs driver", journal.PriInfo)
-	err = l.Start(la.globalArgs.UID, la.globalArgs.GID, la.globalArgs.CleanupTime, ready)
+	debug.SendEventsToJournal(logger.DaemonName, "Starting awslogs driver", journal.PriInfo, 0)
+	err = l.Start(ctx, la.globalArgs.UID, la.globalArgs.GID, la.globalArgs.CleanupTime, ready)
 	if err != nil {
-		return errors.Wrap(err, "failed to start awslogs driver")
+		debug.LoggerErr = errors.Wrap(err, "failed to run awslogs driver")
+		// Do not return error if log driver has issue sending logs to destination, because if error
+		// returned here, containerd will identify this error and kill shim process, which will kill
+		// the container process accordingly.
+		// Note: the container will continue to run if shim logger exits after.
+		// Reference: https://github.com/containerd/containerd/blob/release/1.3/runtime/v2/logging/logging.go
+		return nil
 	}
-	debug.SendEventsToJournal(logger.DaemonName, "Logging finished", journal.PriInfo)
+	debug.SendEventsToJournal(logger.DaemonName, "Logging finished", journal.PriInfo, 1)
 
 	return nil
 }

--- a/logger/fluentd/logger.go
+++ b/logger/fluentd/logger.go
@@ -58,6 +58,8 @@ func InitLogger(globalArgs *logger.GlobalArgs, fluentdArgs *Args) *LoggerArgs {
 }
 
 func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, ready func() error) error {
+	defer debug.DeferFuncForRunLogDriver()
+
 	loggerConfig := getFluentdConfig(la.args)
 	info := logger.NewInfo(
 		la.globalArgs.ContainerID,
@@ -66,7 +68,8 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 	)
 	stream, err := dockerfluentd.New(*info)
 	if err != nil {
-		return errors.Wrap(err, "unable to create stream")
+		debug.LoggerErr = errors.Wrap(err, "unable to create stream")
+		return debug.LoggerErr
 	}
 
 	l, err := logger.NewLogger(
@@ -76,21 +79,28 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 		logger.WithStream(stream),
 	)
 	if err != nil {
-		return errors.Wrap(err, "unable to create fluentd driver")
+		debug.LoggerErr = errors.Wrap(err, "unable to create fluentd driver")
+		return debug.LoggerErr
 	}
 
 	if la.globalArgs.Mode == logger.NonBlockingMode {
-		debug.SendEventsToJournal(logger.DaemonName, "Starting non-blocking mode driver", journal.PriInfo)
+		debug.SendEventsToJournal(logger.DaemonName, "Starting non-blocking mode driver", journal.PriInfo, 0)
 		l = logger.NewBufferedLogger(l, la.globalArgs.MaxBufferSize)
 	}
 
 	// Start fluentd driver
-	debug.SendEventsToJournal(logger.DaemonName, "Starting fluentd driver", journal.PriInfo)
-	err = l.Start(la.globalArgs.UID, la.globalArgs.GID, la.globalArgs.CleanupTime, ready)
+	debug.SendEventsToJournal(logger.DaemonName, "Starting fluentd driver", journal.PriInfo, 0)
+	err = l.Start(ctx, la.globalArgs.UID, la.globalArgs.GID, la.globalArgs.CleanupTime, ready)
 	if err != nil {
-		return errors.Wrap(err, "failed to start fluentd driver")
+		debug.LoggerErr = errors.Wrap(err, "failed to run fluentd driver")
+		// Do not return error if log driver has issue sending logs to destination, because if error
+		// returned here, containerd will identify this error and kill shim process, which will kill
+		// the container process accordingly.
+		// Note: the container will continue to run if shim logger exits after.
+		// Reference: https://github.com/containerd/containerd/blob/release/1.3/runtime/v2/logging/logging.go
+		return nil
 	}
-	debug.SendEventsToJournal(logger.DaemonName, "Logging finished", journal.PriInfo)
+	debug.SendEventsToJournal(logger.DaemonName, "Logging finished", journal.PriInfo, 1)
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func init() {
 func main() {
 	pflag.Parse()
 	if err := run(); err != nil {
-		debug.SendEventsToJournal(logger.DaemonName, err.Error(), journal.PriErr)
+		debug.SendEventsToJournal(logger.DaemonName, err.Error(), journal.PriErr, 1)
 		os.Exit(1)
 	}
 }
@@ -51,7 +51,7 @@ func run() error {
 
 	debug.Verbose = viper.GetBool(verboseKey)
 	if debug.Verbose {
-		debug.SendEventsToJournal(logger.DaemonName, "Using verbose mode", journal.PriInfo)
+		debug.SendEventsToJournal(logger.DaemonName, "Using verbose mode", journal.PriInfo, 0)
 		// If in Verbose mode, start a goroutine to catch os signal and print stack trace
 		debug.StartStackTraceHandler()
 	}
@@ -67,7 +67,7 @@ func run() error {
 	}
 
 	logDriver := globalArgs.LogDriver
-	debug.SendEventsToJournal(logger.DaemonName, "Driver: "+logDriver, journal.PriInfo)
+	debug.SendEventsToJournal(logger.DaemonName, "Driver: "+logDriver, journal.PriInfo, 0)
 	switch logDriver {
 	case awslogsDriverName:
 		if err := runAWSLogsDriver(globalArgs); err != nil {


### PR DESCRIPTION
This commit adds delaySeconds option for sending logs to journald before shim
logger process exits.

Also handle error log messages from child go routine and send them to journald
directly rather than simply return it to containerd. Note if container has started to
run, we only send the error message to journald and return nil to containerd. Otherwise
containerd will kill shim process due to error returned from shim logger, and the container
process will exit with code 1 accordingly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
