### PR TITLE
Handle long log message

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect
 	github.com/aws/amazon-ecs-agent v1.35.0
 	github.com/aws/aws-sdk-go v1.26.8 // indirect
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/containerd/containerd v1.3.0
 	github.com/containerd/fifo v0.0.0-20191213151349-ff969a566b00 // indirect
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
@@ -17,18 +18,20 @@ require (
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/mock v1.1.1
 	github.com/google/go-cmp v0.3.1 // indirect
+	github.com/kr/pretty v0.2.0 // indirect
 	github.com/mattn/go-shellwords v1.0.6 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/pkg/errors v0.8.1
-	github.com/sirupsen/logrus v1.4.2 // indirect
+	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.2
+	github.com/stretchr/testify v1.4.0
 	github.com/tinylib/msgp v1.1.1 // indirect
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/grpc v1.26.0 // indirect
-	gotest.tools v2.2.0+incompatible // indirect
+	gotest.tools v2.2.0+incompatible
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
+github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/containerd/containerd v1.3.0 h1:xjvXQWABwS2uiv3TWgQt5Uth60Gu86LTGZXMJkjc7rY=
@@ -78,6 +80,11 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-shellwords v1.0.6 h1:9Jok5pILi5S1MnDirGVTufYGtksUs/V2BWUP3ZkeUUI=

--- a/logger/awslogs/logger.go
+++ b/logger/awslogs/logger.go
@@ -34,6 +34,13 @@ const (
 	MultilinePatternKey    = "awslogs-multiline-pattern"
 	DatetimeFormatKey      = "awslogs-datetime-format"
 	CredentialsEndpointKey = "awslogs-credentials-endpoint"
+
+	// There are 26 bytes additional bytes for each log event:
+	// See more details in: http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
+	perEventBytes = 26
+	// The value of maximumBytesPerEvent is adopted from Docker. Reference:
+	// https://github.com/moby/moby/blob/19.03/daemon/logger/awslogs/cloudwatchlogs.go#L58
+	maximumBytesPerEvent = 262144 - perEventBytes
 )
 
 // Args represents AWSlogs driver arguments
@@ -85,6 +92,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 		logger.WithStderr(config.Stderr),
 		logger.WithInfo(info),
 		logger.WithStream(stream),
+		logger.WithBufferSizeInBytes(maximumBytesPerEvent),
 	)
 	if err != nil {
 		debug.LoggerErr = errors.Wrap(err, "unable to create awslogs driver")

--- a/logger/buffered_logger.go
+++ b/logger/buffered_logger.go
@@ -244,7 +244,7 @@ func (bl *bufferedLogger) send() error {
 		return errors.Wrap(err, "failed to read logs from buffer")
 	}
 
-	err = bl.LogWithRetry(msg.line, msg.source, msg.logTime)
+	err = bl.Log(msg.line, msg.source, msg.logTime)
 	if err != nil {
 		return errors.Wrap(err, "failed to send logs to destination")
 	}
@@ -257,7 +257,7 @@ func (bl *bufferedLogger) send() error {
 func (bl *bufferedLogger) flushMessages() error {
 	messages := bl.buffer.Flush()
 	for _, msg := range messages {
-		err := bl.LogWithRetry(msg.line, msg.source, msg.logTime)
+		err := bl.Log(msg.line, msg.source, msg.logTime)
 		if err != nil {
 			return errors.Wrap(err, "unable to flush the remaining messages to destination")
 		}
@@ -271,14 +271,14 @@ func (bl *bufferedLogger) GetPipes() (io.Reader, io.Reader) {
 	return bl.l.GetPipes()
 }
 
-// LogWithRetry lets underlying log driver send logs to destination.
-func (bl *bufferedLogger) LogWithRetry(line []byte, source string, logTimestamp time.Time) error {
+// Log lets underlying log driver send logs to destination.
+func (bl *bufferedLogger) Log(line []byte, source string, logTimestamp time.Time) error {
 	if debug.Verbose {
 		debug.SendEventsToJournal(DaemonName,
 			fmt.Sprintf("[BUFFER] Sending message: %s", string(line)),
 			journal.PriDebug, 0)
 	}
-	return bl.l.LogWithRetry(line, source, logTimestamp)
+	return bl.l.Log(line, source, logTimestamp)
 }
 
 // Adopted from https://github.com/moby/moby/blob/master/daemon/logger/ring.go#L155

--- a/logger/common.go
+++ b/logger/common.go
@@ -14,16 +14,16 @@
 package logger
 
 import (
-	"bufio"
+	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"syscall"
 	"time"
 
 	"github.com/aws/shim-loggers-for-containerd/debug"
 
-	"github.com/aws/amazon-ecs-agent/agent/utils/retry"
 	"github.com/coreos/go-systemd/journal"
 	dockerlogger "github.com/docker/docker/daemon/logger"
 	"github.com/pkg/errors"
@@ -38,12 +38,18 @@ const (
 	sourceSTDOUT = "stdout"
 	sourceSTDERR = "stderr"
 
-	// Define the retry parameters for retrying sending logs to destination
-	LogRetryMaxAttempts = 3
-	LogRetryMinBackoff  = 500 * time.Millisecond
-	LogRetryMaxBackoff  = 1 * time.Second
-	LogRetryJitter      = 0.3
-	LogRetryMultiple    = 2
+	newline = '\n'
+
+	// defaultMaxReadBytes is the default maximum bytes read during a single read
+	// operation. Adopted this value from Docker, reference:
+	// https://github.com/moby/moby/blob/19.03/daemon/logger/copier.go#L17
+	defaultMaxReadBytes = 2 * 1024
+
+	// defaultBufSizeInBytes provides a reasonable default for loggers that do
+	// not have an external limit to impose on log line size. Adopted this value
+	// from Docker, reference:
+	// https://github.com/moby/moby/blob/19.03/daemon/logger/copier.go#L21
+	defaultBufSizeInBytes = 16 * 1024
 )
 
 type GlobalArgs struct {
@@ -66,6 +72,13 @@ type Logger struct {
 	Stream Client
 	Stdout io.Reader
 	Stderr io.Reader
+
+	// bufferSizeInBytes defines the size of our own buffer. It's default to
+	// 16 * 1024, but maybe different among log drivers.
+	bufferSizeInBytes int
+	// maxReadBytes defines how many bytes we want to read from container pipe
+	// per iteration. It's default to 2 * 1024.
+	maxReadBytes int
 }
 
 // Client is a wrapper for docker logger's Log method, which is mostly used for testing
@@ -80,14 +93,16 @@ type LogDriver interface {
 	Start(context.Context, int, int, *time.Duration, func() error) error
 	// GetPipes gets pipes of container that exposed by containerd.
 	GetPipes() (io.Reader, io.Reader)
-	// LogWithRetry sends logs to destination with retry.
-	LogWithRetry([]byte, string, time.Time) error
+	// Log sends logs to destination.
+	Log([]byte, string, time.Time) error
 }
 
 // NewLogger creates a LogDriver with the provided LoggerOpt
 func NewLogger(options ...LoggerOpt) (LogDriver, error) {
 	l := &Logger{
-		Info: &dockerlogger.Info{},
+		Info:              &dockerlogger.Info{},
+		bufferSizeInBytes: defaultBufSizeInBytes,
+		maxReadBytes:      defaultMaxReadBytes,
 	}
 	for _, opt := range options {
 		opt(l)
@@ -127,26 +142,27 @@ func (l *Logger) Start(
 	if l.Stdout == nil || l.Stderr == nil {
 		return errors.New("no stdout/stderr pipe opened")
 	}
+	pipeNameToPipe := map[string]io.Reader{
+		sourceSTDOUT: l.Stdout,
+		sourceSTDERR: l.Stderr,
+	}
 
 	errGroup, ctx := errgroup.WithContext(ctx)
-	errGroup.Go(func() error {
-		err := l.sendLogs(ctx, l.Stdout, sourceSTDOUT, uid, gid, cleanupTime)
-		if err != nil {
-			stdoutErr := errors.Wrapf(err, "failed to send logs from pipe %s", sourceSTDOUT)
-			debug.SendEventsToJournal(DaemonName, stdoutErr.Error(), journal.PriErr, 1)
-			return stdoutErr
-		}
-		return nil
-	})
-	errGroup.Go(func() error {
-		err := l.sendLogs(ctx, l.Stderr, sourceSTDERR, uid, gid, cleanupTime)
-		if err != nil {
-			stderrErr := errors.Wrapf(err, "failed to send logs from pipe %s", sourceSTDERR)
-			debug.SendEventsToJournal(DaemonName, stderrErr.Error(), journal.PriErr, 1)
-			return stderrErr
-		}
-		return nil
-	})
+	for pn, p := range pipeNameToPipe {
+		// Copy pn and p to new variables source and pipe, accordingly.
+		source := pn
+		pipe := p
+
+		errGroup.Go(func() error {
+			logErr := l.sendLogs(ctx, pipe, source, uid, gid, cleanupTime)
+			if logErr != nil {
+				err := errors.Wrapf(logErr, "failed to send logs from pipe %s", source)
+				debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
+				return err
+			}
+			return nil
+		})
+	}
 
 	// Signal that the container is ready to be started
 	if err := ready(); err != nil {
@@ -173,98 +189,222 @@ func (l *Logger) sendLogs(
 		return err
 	}
 
-	scanner := bufio.NewScanner(f)
-	scanner.Split(bufio.ScanLines)
+	if err := l.read(ctx, f, source); err != nil {
+		err := errors.Wrapf(err, "failed to read logs from %s pipe", source)
+		debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
+		return err
+	}
+
+	// Sleep sometime to let shim logger clean up, for example, to allow enough time for the last
+	// few log messages be flushed to destination like CloudWatch.
+	debug.SendEventsToJournal(DaemonName,
+		fmt.Sprintf("Pipe %s is closed. Sleeping %s for cleanning up.", source, cleanupTime.String()),
+		journal.PriInfo,
+		0)
+	time.Sleep(*cleanupTime)
+	return nil
+}
+
+// read gets container logs, saves them to our own buffer. Then we will read logs line by line
+// and send them to destination. More log messages will be sent to system journal in verbose mdoe
+// for debugging.
+func (l *Logger) read(ctx context.Context, pipe io.Reader, source string) error {
+	var (
+		partialTimestamp time.Time
+		bytesInBuffer    int
+		err              error
+		eof              bool
+	)
+	// Initiate an in-memory buffer to hold bytes read from container pipe.
+	buf := make([]byte, l.bufferSizeInBytes)
+	// isFirstPartial indicates if current message saved in buffer is not a complete line,
+	// and is the first partial of the whole log message. Initialize to true.
+	isFirstPartial := true
+	// isPartialMsg indicates if current message is a partial log message. Initialize to false.
+	isPartialMsg := false
 	for {
 		select {
 		case <-ctx.Done():
-			debug.SendEventsToJournal(DaemonName,
-				fmt.Sprintf("context canceled in pipe %s", source),
-				journal.PriDebug,
-				1)
+			debug.SendEventsToJournal(l.Info.ContainerID,
+				fmt.Sprintf("Logging stopped in pipe %s", source),
+				journal.PriDebug, 0)
 			return nil
 		default:
-			if scanner.Scan() {
-				if len(scanner.Text()) == 0 {
-					debug.SendEventsToJournal(DaemonName,
-						"Message is empty, skip saving", journal.PriInfo, 0)
-					continue
-				}
-				if err := l.read(scanner, source); err != nil {
-					debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
-					return err
-				}
-			}
-			if scanner.Err() != nil {
-				err := errors.Wrapf(scanner.Err(), "failed to scan logs from %s pipe", source)
-				debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
+			eof, bytesInBuffer, err = l.readFromContainerPipe(pipe, buf, bytesInBuffer)
+			if err != nil {
 				return err
 			}
+			// If container pipe is closed and no bytes left in our buffer, directly return.
+			if eof && bytesInBuffer == 0 {
+				return nil
+			}
 
-			debug.SendEventsToJournal(DaemonName,
-				fmt.Sprintf("Pipe %s is closed. Sleeping %s for cleanning up.", source, cleanupTime.String()),
-				journal.PriInfo,
-				0)
-			time.Sleep(*cleanupTime)
-			return nil
+			// Iteratively scan the unread part in our own buffer and read logs line by line.
+			// Then send it to destination.
+			head := 0
+			// This function returns -1 if '\n' in not present in buffer.
+			lenOfLine := bytes.IndexByte(buf[head:bytesInBuffer], newline)
+			for lenOfLine >= 0 {
+				curLine := buf[head : head+lenOfLine]
+				err, partialTimestamp, _, _ = l.sendLogMsgToDest(
+					curLine,
+					source,
+					isFirstPartial,
+					isPartialMsg,
+					partialTimestamp,
+				)
+				if err != nil {
+					return err
+				}
+				// Since we have found a newline symbol, it means this line has ended.
+				// Reset flags.
+				isFirstPartial = true
+				isPartialMsg = false
+
+				// Update the index of head of next line message.
+				head += lenOfLine + 1
+				lenOfLine = bytes.IndexByte(buf[head:bytesInBuffer], newline)
+			}
+
+			// If the pipe is closed and the last line does not end with a newline symbol, send whatever left
+			// in the buffer to destination as a single log message. Or if our buffer is full but there is
+			// no newline symbol yet, record it as a partial log message and send it as a single log message
+			// to destination.
+			if eof || bufferIsFull(buf, head, bytesInBuffer) {
+				// Still bytes left in the buffer after we identified all newline symbols.
+				if head < bytesInBuffer {
+					curLine := buf[head:bytesInBuffer]
+					err, partialTimestamp, isFirstPartial, isPartialMsg = l.sendLogMsgToDest(
+						curLine,
+						source,
+						isFirstPartial,
+						true, // Record as a partial message.
+						partialTimestamp,
+					)
+					if err != nil {
+						return err
+					}
+
+					// reset head and bytesInBuffer
+					head = 0
+					bytesInBuffer = 0
+				}
+				// If pipe is closed after we send all bytes left in buffer, then directly return.
+				if eof {
+					return nil
+				}
+			}
+
+			// If there are any bytes left in the buffer, move them to the head and handle them in the
+			// next round.
+			if head > 0 {
+				copy(buf[0:], buf[head:bytesInBuffer])
+				bytesInBuffer -= head
+			}
 		}
 	}
 }
 
-// read gets container logs and sends to destination.
-// More log messages will be sent to system journal
-// in verbose mdoe for debugging.
-func (l *Logger) read(s *bufio.Scanner, source string) error {
-	if s.Err() != nil {
-		return errors.Wrap(s.Err(), "failed to get logs from container")
+// readFromContainerPipe reads bytes from container pipe, upto max read size in bytes of 2048.
+func (l *Logger) readFromContainerPipe(pipe io.Reader, buf []byte, bytesInBuffer int) (bool, int, error) {
+	// eof indicates if we have already met EOF error.
+	eof := false
+	// Decide how many bytes we can read from container pipe for this iteration. It's either
+	// the current bytes in buffer plus 2048 bytes or the available spaces left, whichever is
+	// smaller.
+	readBytesUpto := int(math.Min(float64(bytesInBuffer+l.maxReadBytes), float64(cap(buf))))
+	// Read logs from container pipe if there are available spaces for new log messages.
+	if readBytesUpto > bytesInBuffer {
+		readBytesFromPipe, err := pipe.Read(buf[bytesInBuffer:readBytesUpto])
+		if err != nil {
+			if err != io.EOF {
+				return false, bytesInBuffer, errors.Wrap(err, "failed to read log stream from container pipe")
+			}
+			// Pipe is closed, set flag to true.
+			eof = true
+		}
+		bytesInBuffer += readBytesFromPipe
 	}
 
+	return eof, bytesInBuffer, nil
+}
+
+// bufferIsFull indicates if our own buffer is full.
+func bufferIsFull(buf []byte, head, bytesInBuffer int) bool {
+	return head == 0 && bytesInBuffer == len(buf)
+}
+
+// sendLogMsgToDest sends a single line of log message to destination.
+func (l *Logger) sendLogMsgToDest(
+	line []byte,
+	source string,
+	isFirstPartial, isPartialMsg bool,
+	partialTimestamp time.Time,
+) (error, time.Time, bool, bool) {
+	msgTimestamp, partialTimestamp, isFirstPartial, isPartialMsg := l.getLogTimestamp(
+		isFirstPartial,
+		isPartialMsg,
+		partialTimestamp,
+	)
 	if debug.Verbose {
 		debug.SendEventsToJournal(l.Info.ContainerID,
-			fmt.Sprintf("[SCANNER] Scanned message: %s", s.Text()),
+			fmt.Sprintf("[Pipe %s] Scanned message: %s", source, string(line)),
 			journal.PriDebug, 0)
 	}
-	// Send logs to destination with underlying log driver
-	err := l.LogWithRetry(s.Bytes(), source, time.Now())
+
+	err := l.Log(line, source, msgTimestamp)
 	if err != nil {
-		return errors.Wrap(s.Err(), "failed to send logs to destination")
+		return err, partialTimestamp, isFirstPartial, isPartialMsg
 	}
 
-	return nil
+	return nil, partialTimestamp, isFirstPartial, isPartialMsg
 }
 
-// GetPipes gets pipes of container that exposed by containerd.
-func (l *Logger) GetPipes() (io.Reader, io.Reader) {
-	return l.Stdout, l.Stderr
+// getLogTimestamp gets the timestamp of a log message. It could be current timestamp
+// if it's a new line, or the recorded timestamp from the first partial if it's the other partial
+// messages.
+func (l *Logger) getLogTimestamp(
+	isFirstPartial, isPartialMsg bool,
+	partialTimestamp time.Time,
+) (time.Time, time.Time, bool, bool) {
+	msgTimestamp := time.Now().UTC()
+
+	// If it is not end with with newline for the first time, record it as a partial
+	// message and set it to be the first partial. Then record the timestamp as the
+	// timestamp of the whole log message.
+	if isFirstPartial {
+		partialTimestamp = msgTimestamp
+		if debug.Verbose {
+			debug.SendEventsToJournal(l.Info.ContainerID,
+				fmt.Sprintf("Saving first partial at time %s", partialTimestamp.String()),
+				journal.PriDebug, 0)
+		}
+		// Set isFirstPartial to false and set indicator of partial log message to be true.
+		isFirstPartial = false
+		isPartialMsg = true
+	} else if isPartialMsg {
+		// If there are more partial messages recorded before the current read, use the
+		// recorded timestamp as it of the current message as well.
+		msgTimestamp = partialTimestamp
+		if debug.Verbose {
+			debug.SendEventsToJournal(l.Info.ContainerID,
+				fmt.Sprintf("Setting partial log message to time %s", msgTimestamp.String()),
+				journal.PriDebug, 0)
+		}
+	}
+
+	return msgTimestamp, partialTimestamp, isFirstPartial, isPartialMsg
 }
 
-// LogWithRetry sends logs to destination with retry.
-func (l *Logger) LogWithRetry(line []byte, source string, logTimestamp time.Time) error {
-	retryTimes := 0
+// Log sends logs to destination.
+func (l *Logger) Log(line []byte, source string, logTimestamp time.Time) error {
 	message := newMessage(line, source, logTimestamp)
-	backoff := newBackoff()
-	err := retry.RetryNWithBackoff(
-		backoff,
-		LogRetryMaxAttempts,
-		func() error {
-			retryTimes += 1
-			return l.Stream.Log(message)
-		})
+	err := l.Stream.Log(message)
 	if err != nil {
-		err = errors.Wrapf(err, "sending container logs to destination has been retried for %d times", retryTimes)
-		return err
+		return errors.Wrapf(err, "failed to log msg for container %s", l.Info.ContainerName)
 	}
 
 	return nil
-}
-
-// newBackoff creates a new Backoff object.
-func newBackoff() retry.Backoff {
-	return retry.NewExponentialBackoff(
-		LogRetryMinBackoff,
-		LogRetryMaxBackoff,
-		LogRetryJitter,
-		LogRetryMultiple)
 }
 
 // newMessage creates a new logger message.
@@ -275,6 +415,11 @@ func newMessage(line []byte, source string, logTimestamp time.Time) *dockerlogge
 	msg.Timestamp = logTimestamp
 
 	return msg
+}
+
+// GetPipes gets pipes of container that exposed by containerd.
+func (l *Logger) GetPipes() (io.Reader, io.Reader) {
+	return l.Stdout, l.Stderr
 }
 
 // SetUIDAndGID sets UID and/or GID for current goroutine.

--- a/logger/common_opts.go
+++ b/logger/common_opts.go
@@ -57,8 +57,24 @@ func WithInfo(info *dockerlogger.Info) LoggerOpt {
 	}
 }
 
+// WithStream sets the actual stream of log driver.
 func WithStream(stream Client) LoggerOpt {
 	return func(l *Logger) {
 		l.Stream = stream
+	}
+}
+
+// WithBufferSizeInBytes sets the buffer size of log driver.
+func WithBufferSizeInBytes(size int) LoggerOpt {
+	return func(l *Logger) {
+		l.bufferSizeInBytes = size
+	}
+}
+
+// WithMaxReadBytes sets how many bytes will be read from container
+// pipe per iteration.
+func WithMaxReadBytes(size int) LoggerOpt {
+	return func(l *Logger) {
+		l.maxReadBytes = size
 	}
 }


### PR DESCRIPTION
**Description of changes:**
This commit add two in-memory buffers with size in bytes based on the chosen log driver.
Replace scanner by bufio.reader to consume bytes from container pipe, and save to the
corresponding buffer. Then scanner our own buffer line by line and send them one by one
to destination. Add two more new test cases in unit test to cover partial log messages
and a single long log message.

This commit also removes LogWithRetry logic as the underlying Log function called from
Docker is running asynchronously and thus retry logic here is meaningless.

**Testing:**
1. `make lint` and `make test`
2. Run one container with one single log message 2 bytes longer than the defined buffer size of log driver, I can see two lines shown up in the destination (CloudWatch, Fluentd and Splunk), which is of the same result of it in Docker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
