### PR TITLE
Fix a bug of splitted log

### DIFF
--- a/logger/common.go
+++ b/logger/common.go
@@ -410,7 +410,7 @@ func (l *Logger) Log(line []byte, source string, logTimestamp time.Time) error {
 // newMessage creates a new logger message.
 func newMessage(line []byte, source string, logTimestamp time.Time) *dockerlogger.Message {
 	msg := dockerlogger.NewMessage()
-	msg.Line = line
+	msg.Line = append(msg.Line, line...)
 	msg.Source = source
 	msg.Timestamp = logTimestamp
 


### PR DESCRIPTION
*Description of changes:*

Fixed a bug of splitter logs. The change is made because the underlying docker logger is handling batched log events asynchronously

*Testing*
1. `make test` and `make lint`
2. Manually run container with different combination twslogs driver options multiple times and all worked fine.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
