### PR TITLE
Add docker config variables to shim logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ The following list of arguments apply to all of the shim logger binaries in this
 | uid | No | Set a custom uid for the shim logger process. `0` is not supported. |
 | gid | No | Set a custom gid for the shim logger process. `0` is not supported. |
 | cleanup-time | No | Set a custom time for the shim logger process clean up itself. Set to `5s` (5 seconds) by default. Note the maximum supported value is 12 seconds, since containerd shim sets shim logger cleanup timeout value as 12 seconds. See [reference](https://github.com/containerd/containerd/commit/0dc7c8595627e38ca2b83d17a062b51f384c2025). |
-
+| container-image-id | No | The container image id. This is part of the docker config variables that can be logged by splunk log driver. |
+| container-image-name | No | The container image name. This is part of the docker config variables that can be logged by splunk log driver. |
+| container-env | No | The container environment variables map in json format. This is part of the docker config variables that can be logged by splunk log driver. |
+| container-labels | No | The container labels map in json format. This is part of the docker config variables that can be logged by splunk log driver. |
 
 ### Additional log driver options
 #### Amazon CloudWatch Logs

--- a/args.go
+++ b/args.go
@@ -109,6 +109,8 @@ func getDockerConfigs() (*logger.DockerConfigs, error) {
 		}
 	}
 
+	// Docker config variables are optional
+	// If no docker config variables are passed to shim logger, we will use empty values for them.
 	args := &logger.DockerConfigs{
 		ContainerImageID:   viper.GetString(ContainerImageIDKey),
 		ContainerImageName: viper.GetString(ContainerImageNameKey),

--- a/args_test.go
+++ b/args_test.go
@@ -18,6 +18,7 @@ package main
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"testing"
 	"time"
 
@@ -30,6 +31,23 @@ const (
 	testContainerID   = "test-container-id"
 	testContainerName = "test-container-name"
 	testLogDriver     = "test-log-driver"
+
+	testContainerImageName = "test-contaienr-image-name"
+	testContainerImageID   = "test-contaienr-image-id"
+	testContainerLabels    = "{\"label0\":\"labelValue0\",\"label1\":\"labelValue1\"}"
+	testContainerEnv       = "{\"env0\":\"envValue0\",\"env1\":\"envValue1\"}"
+)
+
+var (
+	testContainerLabelsMap = map[string]string{
+		"label0": "labelValue0",
+		"label1": "labelValue1",
+	}
+
+	testContainerEnvSlice = [2]string{
+		"env0=envValue0",
+		"env1=envValue1",
+	}
 )
 
 // TestGetGlobalArgs tests getGlobalArgs with/without correct settings of
@@ -231,4 +249,49 @@ func testGetCleanupTimeWithError(t *testing.T) {
 		_, err := getCleanupTime()
 		require.Error(t, err)
 	}
+}
+
+// TestGetDockerConfigs tests that we can correctly get the docker config input parameters
+func TestGetDockerConfigs(t *testing.T) {
+	t.Run("NoError", testGetDockerConfigsNoError)
+	t.Run("Empty", testGetDockerConfigsEmpty)
+	t.Run("WithError", testGetDockerConfigsWithError)
+}
+
+// testGetDockerConfigsNoError tests that the correctly formated input can be parsed without error
+func testGetDockerConfigsNoError(t *testing.T) {
+	defer viper.Reset()
+
+	viper.Set(ContainerImageNameKey, testContainerImageName)
+	viper.Set(ContainerImageIDKey, testContainerImageID)
+	viper.Set(ContainerLabelsKey, testContainerLabels)
+	viper.Set(ContainerEnvKey, testContainerEnv)
+
+	args, err := getDockerConfigs()
+	require.NoError(t, err)
+	assert.Equal(t, args.ContainerImageName, testContainerImageName)
+	assert.Equal(t, args.ContainerImageID, testContainerImageID)
+	assert.Equal(t, true, reflect.DeepEqual(args.ContainerLabels, testContainerLabelsMap))
+	for i := range args.ContainerEnv {
+		assert.Equal(t, args.ContainerEnv[i], testContainerEnvSlice[i])
+	}
+}
+
+// testGetDockerConfigsEmpty tests that empty docker config input parameter generates no error
+func testGetDockerConfigsEmpty(t *testing.T) {
+	defer viper.Reset()
+
+	_, err := getDockerConfigs()
+	require.NoError(t, err)
+}
+
+// testGetDockerConfigsWithError tests that malformat docker config results in an error
+func testGetDockerConfigsWithError(t *testing.T) {
+	defer viper.Reset()
+	testCaseWithError := "{invalidJsonMap"
+
+	viper.Set(ContainerLabelsKey, testCaseWithError)
+	viper.Set(ContainerEnvKey, testCaseWithError)
+	_, err := getDockerConfigs()
+	require.Error(t, err)
 }

--- a/args_test.go
+++ b/args_test.go
@@ -32,8 +32,8 @@ const (
 	testContainerName = "test-container-name"
 	testLogDriver     = "test-log-driver"
 
-	testContainerImageName = "test-contaienr-image-name"
-	testContainerImageID   = "test-contaienr-image-id"
+	testContainerImageName = "test-container-image-name"
+	testContainerImageID   = "test-container-image-id"
 	testContainerLabels    = "{\"label0\":\"labelValue0\",\"label1\":\"labelValue1\"}"
 	testContainerEnv       = "{\"env0\":\"envValue0\",\"env1\":\"envValue1\"}"
 )
@@ -258,7 +258,7 @@ func TestGetDockerConfigs(t *testing.T) {
 	t.Run("WithError", testGetDockerConfigsWithError)
 }
 
-// testGetDockerConfigsNoError tests that the correctly formated input can be parsed without error
+// testGetDockerConfigsNoError tests that the correctly formatted input can be parsed without error
 func testGetDockerConfigsNoError(t *testing.T) {
 	defer viper.Reset()
 
@@ -269,11 +269,11 @@ func testGetDockerConfigsNoError(t *testing.T) {
 
 	args, err := getDockerConfigs()
 	require.NoError(t, err)
-	assert.Equal(t, args.ContainerImageName, testContainerImageName)
-	assert.Equal(t, args.ContainerImageID, testContainerImageID)
+	assert.Equal(t, testContainerImageName, args.ContainerImageName)
+	assert.Equal(t, testContainerImageID, args.ContainerImageID)
 	assert.Equal(t, true, reflect.DeepEqual(args.ContainerLabels, testContainerLabelsMap))
 	for i := range args.ContainerEnv {
-		assert.Equal(t, args.ContainerEnv[i], testContainerEnvSlice[i])
+		assert.Equal(t, testContainerEnvSlice[i], args.ContainerEnv[i])
 	}
 }
 

--- a/debug/debug.go
+++ b/debug/debug.go
@@ -30,7 +30,7 @@ const (
 
 var (
 	// When this set to true, logger will print more events for debugging
-	Verbose = false
+	Verbose   = false
 	LoggerErr error
 )
 

--- a/go.mod
+++ b/go.mod
@@ -35,3 +35,5 @@ require (
 	google.golang.org/grpc v1.26.0 // indirect
 	gotest.tools v2.2.0+incompatible
 )
+
+go 1.13

--- a/init.go
+++ b/init.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/shim-loggers-for-containerd/logger/awslogs"
 	"github.com/aws/shim-loggers-for-containerd/logger/fluentd"
 	"github.com/aws/shim-loggers-for-containerd/logger/splunk"
-
 	"github.com/spf13/pflag"
 )
 
@@ -45,6 +44,12 @@ const (
 
 	// cleanup time option
 	cleanupTimeKey = "cleanup-time"
+
+	// docker config options
+	ContainerImageIDKey   = "container-image-id"
+	ContainerImageNameKey = "container-image-name"
+	ContainerEnvKey       = "container-env"
+	ContainerLabelsKey    = "container-labels"
 )
 
 // initCommonLogOpts initialize common options that get used by any log drivers
@@ -69,6 +74,14 @@ func initCommonLogOpts() {
 
 	// cleanup time option
 	pflag.String(cleanupTimeKey, "5s", "Cleanup time after pipes are closed, default to 5 seconds")
+}
+
+// initDockerConfigOpts initialize the docker configuration variables for the container
+func initDockerConfigOpts() {
+	pflag.String(ContainerImageIDKey, "", "Image id of the container")
+	pflag.String(ContainerImageNameKey, "", "Image name of the container")
+	pflag.String(ContainerEnvKey, "", "Environment variables of the container")
+	pflag.String(ContainerLabelsKey, "", "Labels of the container")
 }
 
 // initAWSLogsOpts initialize awslogs driver specified options

--- a/logger/common.go
+++ b/logger/common.go
@@ -66,6 +66,14 @@ type GlobalArgs struct {
 	CleanupTime   *time.Duration
 }
 
+// Optional docker config arguments
+type DockerConfigs struct {
+	ContainerImageID 	string
+	ContainerImageName  string
+	ContainerEnv        []string
+	ContainerLabels     map[string]string
+}
+
 // Basic Logger struct for all log drivers
 type Logger struct {
 	Info   *dockerlogger.Info
@@ -128,6 +136,15 @@ func NewInfo(containerID string, containerName string, options ...InfoOpt) *dock
 		opt(info)
 	}
 
+	return info
+}
+
+// UpdateDockerConfigs updates the docker config fields to the logger info.
+func UpdateDockerConfigs(info *dockerlogger.Info, dockerConfigs *DockerConfigs) *dockerlogger.Info {
+	info.ContainerImageName = dockerConfigs.ContainerImageName
+	info.ContainerImageID = dockerConfigs.ContainerImageID
+	info.ContainerLabels = dockerConfigs.ContainerLabels
+	info.ContainerEnv = dockerConfigs.ContainerEnv
 	return info
 }
 

--- a/logger/common.go
+++ b/logger/common.go
@@ -68,10 +68,10 @@ type GlobalArgs struct {
 
 // Optional docker config arguments
 type DockerConfigs struct {
-	ContainerImageID 	string
-	ContainerImageName  string
-	ContainerEnv        []string
-	ContainerLabels     map[string]string
+	ContainerImageID   string
+	ContainerImageName string
+	ContainerEnv       []string
+	ContainerLabels    map[string]string
 }
 
 // Basic Logger struct for all log drivers

--- a/logger/splunk/logger.go
+++ b/logger/splunk/logger.go
@@ -75,13 +75,15 @@ type Args struct {
 // LoggerArgs stores global logger args and splunk specific args
 type LoggerArgs struct {
 	globalArgs *logger.GlobalArgs
+	dockerConfigs *logger.DockerConfigs
 	args       *Args
 }
 
 // InitLogger initialize the input arguments
-func InitLogger(globalArgs *logger.GlobalArgs, splunkArgs *Args) *LoggerArgs {
+func InitLogger(globalArgs *logger.GlobalArgs, dockerConfigs *logger.DockerConfigs, splunkArgs *Args) *LoggerArgs {
 	return &LoggerArgs{
 		globalArgs: globalArgs,
+		dockerConfigs: dockerConfigs,
 		args:       splunkArgs,
 	}
 }
@@ -96,6 +98,8 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 		la.globalArgs.ContainerName,
 		logger.WithConfig(loggerConfig),
 	)
+	info = logger.UpdateDockerConfigs(info, la.dockerConfigs)
+
 	stream, err := dockersplunk.New(*info)
 	if err != nil {
 		debug.LoggerErr = errors.Wrap(err, "unable to create stream")

--- a/logger/splunk/logger.go
+++ b/logger/splunk/logger.go
@@ -74,17 +74,17 @@ type Args struct {
 
 // LoggerArgs stores global logger args and splunk specific args
 type LoggerArgs struct {
-	globalArgs *logger.GlobalArgs
+	globalArgs    *logger.GlobalArgs
 	dockerConfigs *logger.DockerConfigs
-	args       *Args
+	args          *Args
 }
 
 // InitLogger initialize the input arguments
 func InitLogger(globalArgs *logger.GlobalArgs, dockerConfigs *logger.DockerConfigs, splunkArgs *Args) *LoggerArgs {
 	return &LoggerArgs{
-		globalArgs: globalArgs,
+		globalArgs:    globalArgs,
 		dockerConfigs: dockerConfigs,
-		args:       splunkArgs,
+		args:          splunkArgs,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ import (
 
 func init() {
 	initCommonLogOpts()
+	initDockerConfigOpts()
 	initAWSLogsOpts()
 	initFluentdOpts()
 	initSplunkOpts()
@@ -104,11 +105,17 @@ func runFluentdDriver(globalArgs *logger.GlobalArgs) {
 }
 
 func runSplunkDriver(globalArgs *logger.GlobalArgs) error {
+	dockerConfigs, err := getDockerConfigs()
+	if err != nil {
+		return errors.Wrap(err, "unable to get docker config arguments")
+	}
+
 	args, err := getSplunkArgs()
 	if err != nil {
 		return errors.Wrap(err, "unable to get splunk specified arguments")
 	}
-	loggerArgs := splunk.InitLogger(globalArgs, args)
+
+	loggerArgs := splunk.InitLogger(globalArgs, dockerConfigs, args)
 	logging.Run(loggerArgs.RunLogDriver)
 
 	return nil


### PR DESCRIPTION
*Description of changes:*
This change adds the docker config variables as shim logger parameters. The customers can now pass in docker config variables to include container environment, container label, and [container tags](https://docs.docker.com/config/containers/logging/log_tags/) in the log line. 

*Testing*
`make build` and `make test` and `make lint` all pass.
Test alongside with a change on the fargate agent side to pass the docker config to the splunk logdriver, and see that the environment variables, labels, and tags are correctly shown in the log: 

```
{
   attrs: {
     TEST: false 
     TEST2: true 
     TEST3: IDK 
     region: us-east-1 
     service: fargatetest 
   } 
   line: splunk_test_log_0 
   source: stdout 
   tag: docker.io/library/nginx:latest 
} 

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
