### PR TITLE
Handle long log messages in  non-blocking mode

### DIFF
--- a/logger/awslogs/logger.go
+++ b/logger/awslogs/logger.go
@@ -101,7 +101,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 
 	if la.globalArgs.Mode == logger.NonBlockingMode {
 		debug.SendEventsToJournal(logger.DaemonName, "Starting non-blocking mode driver", journal.PriInfo, 0)
-		l = logger.NewBufferedLogger(l, la.globalArgs.MaxBufferSize)
+		l = logger.NewBufferedLogger(l, la.globalArgs.MaxBufferSize, la.globalArgs.ContainerID)
 	}
 
 	// Start awslogs driver

--- a/logger/buffered_logger.go
+++ b/logger/buffered_logger.go
@@ -14,7 +14,6 @@
 package logger
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -24,26 +23,29 @@ import (
 	"github.com/aws/shim-loggers-for-containerd/debug"
 
 	"github.com/coreos/go-systemd/journal"
+	dockerlogger "github.com/docker/docker/daemon/logger"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
-// bufferedLogger is a wrapper of underlying log driver and an
-// intermediate buffer between container pipes and underlying log
-// driver.
+const (
+	expectedNumOfPipes = 2
+	// This value is adopted from Docker:
+	// https://github.com/moby/moby/blob/master/daemon/logger/ring.go#L140
+	ringCap = 1000
+)
+
+// bufferedLogger is a wrapper of underlying log driver and an intermediate ring
+// buffer between container pipes and underlying log driver.
 type bufferedLogger struct {
-	l      LogDriver
-	buffer *logBuffer
-	// closedPipe is a channel listens to goroutine who sends logs from buffer
-	// to destination to get notification from the other two goroutines, who scan
-	// the container io pipes, that both the pipes are closed. At that time,
-	// logger flushes all the messages left in the buffer to destination and
-	// clear the buffer.
-	closedPipes chan bool
+	l           LogDriver
+	buffer      *ringBuffer
+	containerID string
 }
 
 // Adopted from https://github.com/moby/moby/blob/master/daemon/logger/ring.go#L128
 // as this struct is not exported.
-type logBuffer struct {
+type ringBuffer struct {
 	// A mutex lock is used here when writing/reading log messages from the queue
 	// as there exists three go routines accessing the buffer.
 	lock sync.Mutex
@@ -56,38 +58,36 @@ type logBuffer struct {
 	maxSizeInBytes int
 	// queue saves all the log messages read from pipes exposed by containerd, and
 	// is consumed by underlying log driver.
-	queue []*msg
-}
-
-// msg stores a single line of log message, source pipe name (stdout/stderr),
-// and the timestamp that the log obtained from the pipe.
-type msg struct {
-	line    []byte
-	source  string
-	logTime time.Time
+	queue []*dockerlogger.Message
+	// closedPipesCount is the number of closed container pipes for a single container.
+	closedPipesCount int
+	// isClosed indicates if ring buffer is closed.
+	isClosed bool
 }
 
 // NewBufferedLogger creates a logger with the provided LoggerOpt,
 // a buffer with customized max size and a channel monitor if stdout
 // and stderr pipes are closed.
-func NewBufferedLogger(l LogDriver, maxBufferSize int) LogDriver {
+func NewBufferedLogger(l LogDriver, maxBufferSize int, containerID string) LogDriver {
 	return &bufferedLogger{
 		l:           l,
 		buffer:      newLoggerBuffer(maxBufferSize),
-		closedPipes: make(chan bool, 2),
+		containerID: containerID,
 	}
 }
 
 // newLoggerBuffer creates a buffer that stores messages which are
 // from container and consumed by sub-level log drivers.
-func newLoggerBuffer(maxBufferSize int) *logBuffer {
-	lb := &logBuffer{
-		maxSizeInBytes: maxBufferSize,
-		queue:          make([]*msg, 0),
+func newLoggerBuffer(maxBufferSize int) *ringBuffer {
+	rb := &ringBuffer{
+		maxSizeInBytes:   maxBufferSize,
+		queue:            make([]*dockerlogger.Message, 0, ringCap),
+		closedPipesCount: 0,
+		isClosed:         false,
 	}
-	lb.wait = sync.NewCond(&lb.lock)
+	rb.wait = sync.NewCond(&rb.lock)
 
-	return lb
+	return rb
 }
 
 // Start starts the non-blocking mode logger.
@@ -98,153 +98,165 @@ func (bl *bufferedLogger) Start(
 	cleanupTime *time.Duration,
 	ready func() error,
 ) error {
-	stdout, stderr := bl.l.GetPipes()
-	if stdout == nil || stderr == nil {
-		return errors.New("no stdout/stderr pipe opened")
+	pipeNameToPipe, err := bl.l.GetPipes()
+	if err != nil {
+		return err
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(1)
-	debug.SendEventsToJournal(DaemonName,
-		"Starting reading from stdout pipe",
-		journal.PriInfo, 0)
-	go bl.saveLogsToBuffer(stdout, &wg, sourceSTDOUT, uid, gid)
+	errGroup, ctx := errgroup.WithContext(ctx)
+	// Start the goroutine of underlying log driver to consume logs from ring buffer and
+	// send logs to destination when there's any.
+	errGroup.Go(func() error {
+		debug.SendEventsToJournal(DaemonName, "Starting consuming logs from ring buffer", journal.PriInfo, 0)
+		return bl.sendLogMessagesToDestination(uid, gid, cleanupTime)
+	})
 
-	wg.Add(1)
-	debug.SendEventsToJournal(DaemonName,
-		"Starting reading from stderr pipe",
-		journal.PriInfo, 0)
-	go bl.saveLogsToBuffer(stderr, &wg, sourceSTDERR, uid, gid)
+	// Start reading logs from container pipes.
+	for pn, p := range pipeNameToPipe {
+		// Copy pn and p to new variables source and pipe, accordingly.
+		source := pn
+		pipe := p
+
+		errGroup.Go(func() error {
+			logErr := bl.saveLogMessagesToRingBuffer(ctx, pipe, source, uid, gid)
+			if logErr != nil {
+				err := errors.Wrapf(logErr, "failed to send logs from pipe %s", source)
+				debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
+				return err
+			}
+			return nil
+		})
+	}
 
 	// Signal that the container is ready to be started
 	if err := ready(); err != nil {
-		return errors.Wrap(err, "failed to notify container ready status to containerd")
+		return errors.Wrap(err, "failed to check container ready status")
 	}
 
-	// Start the underling log driver to send logs to destination
-	wg.Add(1)
-	go bl.sendLogs(&wg, uid, gid, cleanupTime)
-
-	wg.Wait()
-	debug.SendEventsToJournal(DaemonName,
-		"All logs saved to buffer has been sent to destination",
-		journal.PriInfo, 1)
-
-	return nil
+	// Wait() will return the first error it receives.
+	return errGroup.Wait()
 }
 
-// saveLogsToBuffer saves container logs to intermediate buffer.
-func (bl *bufferedLogger) saveLogsToBuffer(f io.Reader, wg *sync.WaitGroup, source string, uid int, gid int) {
-	defer wg.Done()
-
+// saveLogMessagesToRingBuffer saves container log messages to ring buffer.
+func (bl *bufferedLogger) saveLogMessagesToRingBuffer(
+	ctx context.Context,
+	f io.Reader,
+	source string,
+	uid int, gid int,
+) error {
 	// Set uid for this goroutine. Currently the Setuid syscall does not
 	// apply on threads in golang, see issue: https://github.com/golang/go/issues/1435
 	// TODO: remove it once the changes are released: https://go-review.googlesource.com/c/go/+/210639
 	if err := SetUIDAndGID(uid, gid); err != nil {
 		debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
-		return
+		return err
 	}
 
-	scanner := bufio.NewScanner(f)
-	scanner.Split(bufio.ScanLines)
-	// Scan function breaks either when catch EOF error or there exists error
-	// scanning message except for EOF error.
-	for scanner.Scan() {
-		if len(scanner.Text()) == 0 {
-			debug.SendEventsToJournal(DaemonName,
-				"Message is empty, skip saving", journal.PriInfo, 0)
-			continue
-		}
-		if err := bl.read(scanner, source); err != nil {
-			debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
-			return
-		}
+	if err := bl.Read(ctx, f, source, defaultBufSizeInBytes, bl.saveSingleLogMessageToRingBuffer); err != nil {
+		err := errors.Wrapf(err, "failed to read logs from %s pipe", source)
+		debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
+		return err
 	}
 
-	// No messages in the pipe, send signal to closed pipe channel
-	debug.SendEventsToJournal(DaemonName, "Pipe closed", journal.PriInfo, 1)
-	bl.closedPipes <- true
+	// No messages in the pipe, send signal to closed pipe channel.
+	debug.SendEventsToJournal(DaemonName, fmt.Sprintf("Pipe %s is closed", source), journal.PriInfo, 1)
+	bl.buffer.closedPipesCount++
+	// If both container pipes are closed, wake up the Dequeue goroutine which is waiting on wait.
+	if bl.buffer.closedPipesCount == expectedNumOfPipes {
+		bl.buffer.isClosed = true
+		bl.buffer.wait.Broadcast()
+	}
+
+	return nil
 }
 
-// read reads a single log message from pipe and saves it to buffer.
-func (bl *bufferedLogger) read(s *bufio.Scanner, source string) error {
-	if s.Err() != nil {
-		return errors.Wrap(s.Err(), "failed to get logs from container")
-	}
+// Read reads log messages from container pipe and saves them to ring buffer line by line.
+func (bl *bufferedLogger) Read(
+	ctx context.Context,
+	pipe io.Reader,
+	source string,
+	bufferSizeInBytes int,
+	sendLogMsgToDest sendLogToDestFunc,
+) error {
+	return bl.l.Read(ctx, pipe, source, bufferSizeInBytes, sendLogMsgToDest)
+}
+
+// saveSingleLogMessageToRingBuffer enqueues a single line of log message to ring buffer.
+func (bl *bufferedLogger) saveSingleLogMessageToRingBuffer(
+	line []byte,
+	source string,
+	isFirstPartial, isPartialMsg bool,
+	partialTimestamp time.Time,
+) (error, time.Time, bool, bool) {
+	msgTimestamp, partialTimestamp, isFirstPartial, isPartialMsg := getLogTimestamp(
+		isFirstPartial,
+		isPartialMsg,
+		partialTimestamp,
+		bl.containerID,
+	)
 	if debug.Verbose {
-		debug.SendEventsToJournal(DaemonName,
-			fmt.Sprintf("[SCANNER] Scanned msg: %s", s.Text()),
-			journal.PriDebug, 0)
-		debug.SendEventsToJournal(DaemonName,
-			fmt.Sprintf("current buffer size: %d", bl.buffer.curSizeInBytes),
+		debug.SendEventsToJournal(bl.containerID,
+			fmt.Sprintf("[Pipe %s] Scanned message: %s", source, string(line)),
 			journal.PriDebug, 0)
 	}
 
-	logMsg := &msg{
-		line:    s.Bytes(),
-		source:  source,
-		logTime: time.Now(),
-	}
-	err := bl.buffer.Enqueue(logMsg)
+	message := newMessage(line, source, msgTimestamp)
+	err := bl.buffer.Enqueue(message)
 	if err != nil {
-		return errors.Wrap(s.Err(), "failed to save logs to buffer")
+		err := errors.Wrap(err, "failed to save logs to buffer")
+		return err, partialTimestamp, isFirstPartial, isPartialMsg
 	}
 
-	return nil
+	return nil, partialTimestamp, isFirstPartial, isPartialMsg
 }
 
-// sendLogs consumes logs from intermediate buffer and use the
-// underlying log drive to send logs to destination.
-func (bl *bufferedLogger) sendLogs(wg *sync.WaitGroup, uid int, gid int, cleanupTime *time.Duration) {
-	defer wg.Done()
-
+// sendLogMessagesToDestination consumes logs from ring buffer and use the
+// underlying log driver to send logs to destination.
+func (bl *bufferedLogger) sendLogMessagesToDestination(uid int, gid int, cleanupTime *time.Duration) error {
 	// Set uid for this goroutine. Currently the Setuid syscall does not
 	// apply on threads in golang, see issue: https://github.com/golang/go/issues/1435
 	// TODO: remove it once the changes are released: https://go-review.googlesource.com/c/go/+/210639
 	if err := SetUIDAndGID(uid, gid); err != nil {
 		debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
-		return
+		return err
 	}
 
-	count := 0
-	for {
-		select {
-		case <-bl.closedPipes:
-			count++
-			// If received closed pipe signal from both pipes,
-			// flush messages left in buffer.
-			if count == 2 {
-				debug.SendEventsToJournal(DaemonName,
-					"All pipes are closed, closing buffer",
-					journal.PriInfo, 0)
-				if err := bl.flushMessages(); err != nil {
-					debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
-					return
-				}
-
-				debug.SendEventsToJournal(DaemonName,
-					fmt.Sprintf("Sleeping %s for cleanning up.", cleanupTime.String()),
-					journal.PriInfo, 0)
-				time.Sleep(*cleanupTime)
-				return
-			}
-		default:
-			if err := bl.send(); err != nil {
-				debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
-				return
-			}
+	// Keep sending log message to destination defined by the underlying log driver until
+	// the ring buffer is closed.
+	for !bl.buffer.isClosed {
+		if err := bl.sendLogMessageToDestination(); err != nil {
+			debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
+			return err
 		}
 	}
+	// If both container pipes are closed, flush messages left in ring buffer.
+	debug.SendEventsToJournal(DaemonName, "All pipes are closed, flushing buffer.", journal.PriInfo, 0)
+	if err := bl.flushMessages(); err != nil {
+		debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
+		return err
+	}
+
+	// Sleep sometime to let shim logger clean up, for example, to allow enough time for the last
+	// few log messages be flushed to destination like CloudWatch.
+	debug.SendEventsToJournal(DaemonName,
+		fmt.Sprintf("Sleeping %s for cleanning up.", cleanupTime.String()),
+		journal.PriInfo, 0)
+	time.Sleep(*cleanupTime)
+	return nil
 }
 
-// send dequeues a single log message from buffer and sends to destination.
-func (bl *bufferedLogger) send() error {
+// sendLogMessageToDestination dequeues a single log message from buffer and sends to destination.
+func (bl *bufferedLogger) sendLogMessageToDestination() error {
 	msg, err := bl.buffer.Dequeue()
+	// Do an early return if ring buffer is closed.
+	if bl.buffer.isClosed {
+		return nil
+	}
 	if err != nil {
 		return errors.Wrap(err, "failed to read logs from buffer")
 	}
 
-	err = bl.Log(msg.line, msg.source, msg.logTime)
+	err = bl.Log(msg.Line, msg.Source, msg.Timestamp)
 	if err != nil {
 		return errors.Wrap(err, "failed to send logs to destination")
 	}
@@ -252,23 +264,18 @@ func (bl *bufferedLogger) send() error {
 	return nil
 }
 
-// flushMessages flushes all the messages left in the buffer to destination
-// after container pipes are closed.
+// flushMessages flushes all the messages left in the ring buffer to
+// destination after container pipes are closed.
 func (bl *bufferedLogger) flushMessages() error {
 	messages := bl.buffer.Flush()
 	for _, msg := range messages {
-		err := bl.Log(msg.line, msg.source, msg.logTime)
+		err := bl.Log(msg.Line, msg.Source, msg.Timestamp)
 		if err != nil {
 			return errors.Wrap(err, "unable to flush the remaining messages to destination")
 		}
 	}
 
 	return nil
-}
-
-// GetPipes gets pipes of container that exposed by containerd.
-func (bl *bufferedLogger) GetPipes() (io.Reader, io.Reader) {
-	return bl.l.GetPipes()
 }
 
 // Log lets underlying log driver send logs to destination.
@@ -281,18 +288,24 @@ func (bl *bufferedLogger) Log(line []byte, source string, logTimestamp time.Time
 	return bl.l.Log(line, source, logTimestamp)
 }
 
+// GetPipes gets pipes of container and its name that exposed by containerd.
+func (bl *bufferedLogger) GetPipes() (map[string]io.Reader, error) {
+	return bl.l.GetPipes()
+}
+
 // Adopted from https://github.com/moby/moby/blob/master/daemon/logger/ring.go#L155
 // as messageRing struct is not exported.
 // Enqueue adds a single log message to the tail of intermediate buffer.
-func (b *logBuffer) Enqueue(msg *msg) error {
+func (b *ringBuffer) Enqueue(msg *dockerlogger.Message) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	lineSizeInBytes := len(msg.line)
-	// If there is not enough space left for the new coming log message or the message
-	// size is larger than the whole buffer size.
-	if b.curSizeInBytes+lineSizeInBytes > b.maxSizeInBytes ||
-		lineSizeInBytes > b.maxSizeInBytes {
+	lineSizeInBytes := len(msg.Line)
+	// If there is already at least one log message in the queue and not enough space left
+	// for the new coming log message to take up, drop this log message. Otherwise, save this
+	// message to ring buffer anyway.
+	if len(b.queue) > 0 &&
+		b.curSizeInBytes+lineSizeInBytes > b.maxSizeInBytes {
 		if debug.Verbose {
 			debug.SendEventsToJournal(DaemonName,
 				"buffer is full/message is too long, waiting for available bytes",
@@ -323,12 +336,13 @@ func (b *logBuffer) Enqueue(msg *msg) error {
 // Adopted from https://github.com/moby/moby/blob/master/daemon/logger/ring.go#L179
 // as messageRing struct is not exported.
 // Dequeue gets a line of log message from the head of intermediate buffer.
-func (b *logBuffer) Dequeue() (*msg, error) {
+func (b *ringBuffer) Dequeue() (*dockerlogger.Message, error) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	// If there is no logs yet in the buffer, wait suspends current go routine
-	for len(b.queue) == 0 {
+	// If there is no log yet in the buffer, and the ring buffer is still open, wait
+	// suspends current go routine.
+	for len(b.queue) == 0 && !b.isClosed {
 		if debug.Verbose {
 			debug.SendEventsToJournal(DaemonName,
 				"No messages in queue, waiting...",
@@ -337,11 +351,16 @@ func (b *logBuffer) Dequeue() (*msg, error) {
 		b.wait.Wait()
 	}
 
+	// Directly return if ring buffer is closed.
+	if b.isClosed {
+		return nil, nil
+	}
+
 	// Get and remove the oldest message saved in buffer/queue from head and update
 	// the current used bytes of buffer.
 	msg := b.queue[0]
 	b.queue = b.queue[1:]
-	b.curSizeInBytes -= len(msg.line)
+	b.curSizeInBytes -= len(msg.Line)
 
 	return msg, nil
 }
@@ -349,16 +368,16 @@ func (b *logBuffer) Dequeue() (*msg, error) {
 // Adopted from https://github.com/moby/moby/blob/master/daemon/logger/ring.go#L215
 // as messageRing struct is not exported.
 // Flush flushes all the messages left in the buffer and clear queue.
-func (b *logBuffer) Flush() []*msg {
+func (b *ringBuffer) Flush() []*dockerlogger.Message {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
 	if len(b.queue) == 0 {
-		return make([]*msg, 0)
+		return make([]*dockerlogger.Message, 0)
 	}
 
 	messages := b.queue
-	b.queue = make([]*msg, 0)
+	b.queue = make([]*dockerlogger.Message, 0)
 
 	return messages
 }

--- a/logger/buffered_logger_test.go
+++ b/logger/buffered_logger_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	dockerlogger "github.com/docker/docker/daemon/logger"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,17 +28,17 @@ const (
 )
 
 var (
-	messages = []*msg{
-		{line: []byte("line1"), logTime: dummyTime},
-		{line: []byte("line2"), logTime: dummyTime},
-		{line: []byte("line3"), logTime: dummyTime},
-		{line: []byte("testLine4"), logTime: dummyTime},
+	messages = []*dockerlogger.Message{
+		{Line: []byte("line1"), Timestamp: dummyTime},
+		{Line: []byte("line2"), Timestamp: dummyTime},
+		{Line: []byte("line3"), Timestamp: dummyTime},
+		{Line: []byte("testLine4"), Timestamp: dummyTime},
 	}
 )
 
 // testEnqueue tests Enqueue operation without error and gets used
 // as initialization of buffer in Dequeue and Flush tests.
-func testEnqueue(t *testing.T) *logBuffer {
+func testEnqueue(t *testing.T) *ringBuffer {
 	lb := newLoggerBuffer(testBufferSize)
 	require.Equal(t, testBufferSize, lb.maxSizeInBytes)
 	require.Equal(t, 0, lb.curSizeInBytes)
@@ -47,7 +48,7 @@ func testEnqueue(t *testing.T) *logBuffer {
 		expectedCurBufferSize int
 	)
 	for _, msg := range messages {
-		expectedCurBufferSize += len(msg.line)
+		expectedCurBufferSize += len(msg.Line)
 		err = lb.Enqueue(msg)
 		require.NoError(t, err)
 	}

--- a/logger/fluentd/logger.go
+++ b/logger/fluentd/logger.go
@@ -85,7 +85,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 
 	if la.globalArgs.Mode == logger.NonBlockingMode {
 		debug.SendEventsToJournal(logger.DaemonName, "Starting non-blocking mode driver", journal.PriInfo, 0)
-		l = logger.NewBufferedLogger(l, la.globalArgs.MaxBufferSize)
+		l = logger.NewBufferedLogger(l, la.globalArgs.MaxBufferSize, la.globalArgs.ContainerID)
 	}
 
 	// Start fluentd driver

--- a/logger/splunk/logger.go
+++ b/logger/splunk/logger.go
@@ -119,7 +119,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 
 	if la.globalArgs.Mode == logger.NonBlockingMode {
 		debug.SendEventsToJournal(logger.DaemonName, "Starting non-blocking mode driver", journal.PriInfo, 0)
-		l = logger.NewBufferedLogger(l, la.globalArgs.MaxBufferSize)
+		l = logger.NewBufferedLogger(l, la.globalArgs.MaxBufferSize, la.globalArgs.ContainerID)
 	}
 
 	// Start splunk log driver


### PR DESCRIPTION
**Description**
Previously in non-blocking mode, the logger was still using scanner
with split function of ScanLines, which will close the reader side
of container pipe if the token is too long for the scanner to handle,
i.e. when a single log message is larger than the size of container pipe,
the reader will crash and stop consuming logs from container pipe. Thus
the container performance will be blocked. This commit resolves this issue.

**What changes have been made**
1. Removed `Scanner.Scan()` function and reuse `Read` function in common.go to read logs from container pipes, But instead of sending logs to final destination when consuming logs from intermediate buffer, it will save each line to the ring buffer by calling `Enqueue`. And the logs sent to final destination in a separate goroutine by calling `Dequeue`.
2. When there's no message in the ring buffer, or there's space left for next incoming log message, we will save it to the ring buffer. Otherwise this log message will be dropped to meet "non-blocking" purpose.
3. Shared the `Read` function in common.go between common and buffered loggers, by setting `sendLogMsgToDest`  function as an input parameter.
4. Changed `GetPipes()` function to return container pipes in a map and handle nil pipe case as error directly.
5. Modified buffered logger unit tests to meet the code change.

**Testing**
1. `make test` and `make lint`
2.  Ran a container with non-blocking mode and max-buffer-size=5, and the container was consistently streaming log messages larger than 5 bytes. Did observe a couple of log messages were dropped. Ran another container with the same log configuration and observed very similar results with Docker.
3. Ran a container with non-blocking mode and max-buffer-size=500, and the container was consistently streaming log messages smaller than 500 bytes. Did not observe any log messages were dropped. Ran another container with the same log configuration and observed same results with Docker.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
