### PR TITLE
Enabling nanosecond resolution timestamps for firelens

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ You can find a description of what these parameters are used for [here](https://
 The following additional arguments are supported for the `fluentd` shim logger binary, which can be used to send container logs to  [Fluentd](https://www.fluentd.org). Note that all of these are optional arguments.
 * fluentd-address: The address of the Fluentd server to connect to. By default, the `localhost:24224` address is used.
 * fluentd-async-connect: Specifies if the logger connects to Fluentd in background. Defaults to `false`.
+* fluentd-sub-second-precision: Generates logs in nanoseconds. Defaults to `true`. Note that this is in contrast to the default behaviour of fluentd log driver where it defaults to `false`. 
 * fluentd-tag: Specifies the tag used for log messages. Defaults to the first 12 characters of container ID.
 
 ## License

--- a/args.go
+++ b/args.go
@@ -159,10 +159,14 @@ func getFluentdArgs() *fluentd.Args {
 	ac := viper.GetBool(fluentd.AsyncConnectKey)
 	asyncConnect := strconv.FormatBool(ac)
 
+	precision := viper.GetBool(fluentd.SubsecondPrecisionKey)
+	subsecondPrecision := strconv.FormatBool(precision)
+
 	return &fluentd.Args{
-		Address:      address,
-		Tag:          tag,
-		AsyncConnect: asyncConnect,
+		Address:            address,
+		Tag:                tag,
+		AsyncConnect:       asyncConnect,
+		SubsecondPrecision: subsecondPrecision,
 	}
 }
 

--- a/init.go
+++ b/init.go
@@ -99,6 +99,7 @@ func initAWSLogsOpts() {
 func initFluentdOpts() {
 	pflag.String(fluentd.AddressKey, "", "The address connected to Fluentd daemon")
 	pflag.Bool(fluentd.AsyncConnectKey, false, "If connecting Fluentd daemon in background")
+	pflag.Bool(fluentd.SubsecondPrecisionKey, true, "Ensures event logs are generated in nanosecond resolution.")
 	pflag.String(fluentd.FluentdTagKey, "", "The tag used to identify log messages")
 }
 

--- a/logger/fluentd/logger.go
+++ b/logger/fluentd/logger.go
@@ -26,9 +26,10 @@ import (
 )
 
 const (
-	AddressKey      = "fluentd-address"
-	AsyncConnectKey = "fluentd-async-connect"
-	FluentdTagKey   = "fluentd-tag"
+	AddressKey            = "fluentd-address"
+	AsyncConnectKey       = "fluentd-async-connect"
+	FluentdTagKey         = "fluentd-tag"
+	SubsecondPrecisionKey = "fluentd-sub-second-precision"
 
 	// Convert input parameter "fluentd-tag" to the fluentd parameter "tag"
 	// This is to distinguish between the "tag" parameter from the splunk input
@@ -38,9 +39,10 @@ const (
 // Args represents fluentd log driver arguments
 type Args struct {
 	// Optional arguments
-	Address      string
-	AsyncConnect string
-	Tag          string
+	Address            string
+	AsyncConnect       string
+	Tag                string
+	SubsecondPrecision string
 }
 
 // LoggerArgs stores global logger args and fluentd specific args
@@ -111,6 +113,7 @@ func getFluentdConfig(args *Args) map[string]string {
 	config[tagKey] = args.Tag
 	config[AddressKey] = args.Address
 	config[AsyncConnectKey] = args.AsyncConnect
+	config[SubsecondPrecisionKey] = args.SubsecondPrecision
 
 	return config
 }

--- a/logger/fluentd/logger_test.go
+++ b/logger/fluentd/logger_test.go
@@ -22,24 +22,27 @@ import (
 )
 
 const (
-	testAddress      = "testAddress"
-	testAsyncConnect = "false"
-	testTag          = "testTag"
+	testAddress            = "testAddress"
+	testAsyncConnect       = "false"
+	testTag                = "testTag"
+	testSubsecondPrecision = "true"
 )
 
 var (
 	args = &Args{
-		Address:      testAddress,
-		AsyncConnect: testAsyncConnect,
-		Tag:          testTag,
+		Address:            testAddress,
+		AsyncConnect:       testAsyncConnect,
+		SubsecondPrecision: testSubsecondPrecision,
+		Tag:                testTag,
 	}
 )
 
 func TestGetFluentdConfig(t *testing.T) {
 	expectedConfig := map[string]string{
-		AddressKey:      testAddress,
-		AsyncConnectKey: testAsyncConnect,
-		tagKey:          testTag,
+		AddressKey:            testAddress,
+		AsyncConnectKey:       testAsyncConnect,
+		SubsecondPrecisionKey: testSubsecondPrecision,
+		tagKey:                testTag,
 	}
 
 	config := getFluentdConfig(args)


### PR DESCRIPTION
*Summary*
Adding an option - _sub second precision_ to generate firelens event logs in nanosecond resolution.
This is being enabled to resolve the following request aws/containers-roadmap#839

*Description of changes:*
set option fluentd-sub-second-precision to true.

*Testing*
Code change has been tested on Fargate with Warmpool.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
