### PR TITLE
Modify setuid/setgid syscall and only applies it once in main goroutine

### DIFF
--- a/logger/buffered_logger.go
+++ b/logger/buffered_logger.go
@@ -144,14 +144,6 @@ func (bl *bufferedLogger) saveLogMessagesToRingBuffer(
 	source string,
 	uid int, gid int,
 ) error {
-	// Set uid for this goroutine. Currently the Setuid syscall does not
-	// apply on threads in golang, see issue: https://github.com/golang/go/issues/1435
-	// TODO: remove it once the changes are released: https://go-review.googlesource.com/c/go/+/210639
-	if err := SetUIDAndGID(uid, gid); err != nil {
-		debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
-		return err
-	}
-
 	if err := bl.Read(ctx, f, source, defaultBufSizeInBytes, bl.saveSingleLogMessageToRingBuffer); err != nil {
 		err := errors.Wrapf(err, "failed to read logs from %s pipe", source)
 		debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
@@ -213,14 +205,6 @@ func (bl *bufferedLogger) saveSingleLogMessageToRingBuffer(
 // sendLogMessagesToDestination consumes logs from ring buffer and use the
 // underlying log driver to send logs to destination.
 func (bl *bufferedLogger) sendLogMessagesToDestination(uid int, gid int, cleanupTime *time.Duration) error {
-	// Set uid for this goroutine. Currently the Setuid syscall does not
-	// apply on threads in golang, see issue: https://github.com/golang/go/issues/1435
-	// TODO: remove it once the changes are released: https://go-review.googlesource.com/c/go/+/210639
-	if err := SetUIDAndGID(uid, gid); err != nil {
-		debug.SendEventsToJournal(DaemonName, err.Error(), journal.PriErr, 1)
-		return err
-	}
-
 	// Keep sending log message to destination defined by the underlying log driver until
 	// the ring buffer is closed.
 	for !bl.buffer.isClosed {

--- a/main.go
+++ b/main.go
@@ -62,7 +62,12 @@ func run() error {
 		return errors.Wrap(err, "unable to get global arguments")
 	}
 
-	// Set UID and/or GID of main goroutine if specified
+	// Set UID and/or GID of main goroutine/shim logger process if specified.
+	// If you are building with go version includes the following commit, you only need
+	// to call this once in main goroutine. Otherwise you need call this function in all
+	// goroutines to let this syscall work properly.
+	// Commit: https://github.com/golang/go/commit/d1b1145cace8b968307f9311ff611e4bb810710c
+	// TODO: remove the above comment once the changes are released: https://go-review.googlesource.com/c/go/+/210639
 	if err = logger.SetUIDAndGID(globalArgs.UID, globalArgs.GID); err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description of changes:
Previously due to a bug of setuid/setgid syscall in golang, these two syscalls only apply to current goroutine instead of the whole process. With the fix checked in, we are removing the redundant calls of these functions in sub-goroutines.

Note that golang has not included this fix in a specific version, and in order to take it effect, please build shim logger with go built from source.

Golang issue:
https://github.com/golang/go/issues/1435
Golang commit of fix:
https://github.com/golang/go/commit/d1b1145cace8b968307f9311ff611e4bb810710c

### Testing:
1. `make test` and `make lint`
2. Built go from source and use source go built shim logger, run shim logger process with `uid` and `gid` option enabled, I can see process are running with expected UID/GID.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
