### PR TITLE
Only pass splunk tag to logging config if specified

### DIFF
--- a/args.go
+++ b/args.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coreos/go-systemd/journal"
 	"github.com/docker/go-units"
 	"github.com/pkg/errors"
+	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
 
@@ -196,6 +197,7 @@ func getSplunkArgs() (*splunk.Args, error) {
 		Gzip:               viper.GetString(splunk.GzipKey),
 		GzipLevel:          viper.GetString(splunk.GzipLevelKey),
 		Tag:                viper.GetString(splunk.SplunkTagKey),
+		TagSpecified:       isFlagPassed(splunk.SplunkTagKey),
 		Labels:             viper.GetString(splunk.LabelsKey),
 		Env:                viper.GetString(splunk.EnvKey),
 		EnvRegex:           viper.GetString(splunk.EnvRegexKey),
@@ -274,4 +276,15 @@ func getCleanupTime() (*time.Duration, error) {
 	}
 
 	return &duration, nil
+}
+
+// isFlagPassed determines whether a flag was passed by the client.
+func isFlagPassed(name string) bool {
+	passed := false
+	pflag.Visit(func(f *pflag.Flag) {
+		if f.Name == name {
+			passed = true
+		}
+	})
+	return passed
 }

--- a/logger/splunk/logger.go
+++ b/logger/splunk/logger.go
@@ -67,9 +67,13 @@ type Args struct {
 	Gzip               string
 	GzipLevel          string
 	Tag                string
-	Labels             string
-	Env                string
-	EnvRegex           string
+	// TagSpecified represents whether a splunk tag was specified. It is used to differentiate between the default value
+	// of the splunk tag when the flag is initialized and the client specifying the default value of the tag,
+	// as they may be the same.
+	TagSpecified bool
+	Labels       string
+	Env          string
+	EnvRegex     string
 }
 
 // LoggerArgs stores global logger args and splunk specific args
@@ -176,7 +180,7 @@ func getSplunkConfig(arg *Args) map[string]string {
 	if arg.GzipLevel != "" {
 		config[GzipLevelKey] = arg.GzipLevel
 	}
-	if arg.Tag != "" {
+	if arg.TagSpecified {
 		config[tagKey] = arg.Tag
 	}
 	if arg.Labels != "" {

--- a/logger/splunk/logger_test.go
+++ b/logger/splunk/logger_test.go
@@ -33,6 +33,7 @@ const (
 	testGzip               = "true"
 	testGzipLevel          = "0"
 	testSplunkTag          = "tag"
+	testSplunkTagSpecified = true
 	testLabels             = "label0, label1"
 	testEnv                = "envVar0, envVar1"
 	testEnvRegex           = "envVar*"
@@ -53,6 +54,7 @@ var (
 		Gzip:               testGzip,
 		GzipLevel:          testGzipLevel,
 		Tag:                testSplunkTag,
+		TagSpecified:       testSplunkTagSpecified,
 		Labels:             testLabels,
 		Env:                testEnv,
 		EnvRegex:           testEnvRegex,


### PR DESCRIPTION
### Description of changes:

1. Pass the value of `SplunkTagKey` to the logging config only if the flag is set, rather than by determining whether the value is not equal to the default (an empty string).
2. This allows passing an empty string as the value of `SplunkTagKey`. Docker does not tag the logs if the specified tag is an empty string; now this functionality will be supported.

An alternative is use a different default value for `SplunkTagKey`, however this means that there will always be one value (the default) that will be ignored if specified by the customer and will result in the default tag `{{.ID}}` being assumed by Docker.

### Testing:
1. `make lint` `make test`
2. Ran shim logger with `--splunk-tag=""` and verified that it is passed to the logging config. Furthermore, ran a container with this tag and the tag as retrieved from Splunk logs is `null` (expected behavior).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.