### PR TITLE
Enable buffer limit option in FireLens

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The following additional arguments are supported for the `fluentd` shim logger b
 * fluentd-address: The address of the Fluentd server to connect to. By default, the `localhost:24224` address is used.
 * fluentd-async-connect: Specifies if the logger connects to Fluentd in background. Defaults to `false`.
 * fluentd-sub-second-precision: Generates logs in nanoseconds. Defaults to `true`. Note that this is in contrast to the default behaviour of fluentd log driver where it defaults to `false`. 
+* fluentd-buffer-limit: Sets the number of events buffered on the memory. Defaults to `1MB`.
 * fluentd-tag: Specifies the tag used for log messages. Defaults to the first 12 characters of container ID.
 
 ## License

--- a/args.go
+++ b/args.go
@@ -88,8 +88,8 @@ func getWindowsArgs() *logger.WindowsArgs {
 	logDir := viper.GetString(LogFileDirKey)
 
 	return &logger.WindowsArgs{
-		ProxyEnvVar:   proxyVar,
-		LogFileDir:    logDir,
+		ProxyEnvVar: proxyVar,
+		LogFileDir:  logDir,
 	}
 }
 
@@ -174,11 +174,18 @@ func getFluentdArgs() *fluentd.Args {
 	precision := viper.GetBool(fluentd.SubsecondPrecisionKey)
 	subsecondPrecision := strconv.FormatBool(precision)
 
+	buffer := viper.GetInt(fluentd.BufferLimitKey)
+	bufferLimit := ""
+	if buffer > 0 {
+		bufferLimit = strconv.Itoa(buffer)
+	}
+
 	return &fluentd.Args{
 		Address:            address,
 		Tag:                tag,
 		AsyncConnect:       asyncConnect,
 		SubsecondPrecision: subsecondPrecision,
+		BufferLimit:        bufferLimit,
 	}
 }
 

--- a/init.go
+++ b/init.go
@@ -113,6 +113,7 @@ func initFluentdOpts() {
 	pflag.String(fluentd.AddressKey, "", "The address connected to Fluentd daemon")
 	pflag.Bool(fluentd.AsyncConnectKey, false, "If connecting Fluentd daemon in background")
 	pflag.Bool(fluentd.SubsecondPrecisionKey, true, "Ensures event logs are generated in nanosecond resolution.")
+	pflag.Int(fluentd.BufferLimitKey, -1, "The number of events buffered on the memory")
 	pflag.String(fluentd.FluentdTagKey, "", "The tag used to identify log messages")
 }
 

--- a/logger/fluentd/logger.go
+++ b/logger/fluentd/logger.go
@@ -29,6 +29,7 @@ const (
 	AsyncConnectKey       = "fluentd-async-connect"
 	FluentdTagKey         = "fluentd-tag"
 	SubsecondPrecisionKey = "fluentd-sub-second-precision"
+	BufferLimitKey        = "fluentd-buffer-limit"
 
 	// Convert input parameter "fluentd-tag" to the fluentd parameter "tag"
 	// This is to distinguish between the "tag" parameter from the splunk input
@@ -42,6 +43,7 @@ type Args struct {
 	AsyncConnect       string
 	Tag                string
 	SubsecondPrecision string
+	BufferLimit        string
 }
 
 // LoggerArgs stores global logger args and fluentd specific args
@@ -113,6 +115,7 @@ func getFluentdConfig(args *Args) map[string]string {
 	config[AddressKey] = args.Address
 	config[AsyncConnectKey] = args.AsyncConnect
 	config[SubsecondPrecisionKey] = args.SubsecondPrecision
+	config[BufferLimitKey] = args.BufferLimit
 
 	return config
 }

--- a/logger/fluentd/logger_test.go
+++ b/logger/fluentd/logger_test.go
@@ -26,6 +26,7 @@ const (
 	testAsyncConnect       = "false"
 	testTag                = "testTag"
 	testSubsecondPrecision = "true"
+	testBufferLimit        = "12345"
 )
 
 var (
@@ -34,6 +35,7 @@ var (
 		AsyncConnect:       testAsyncConnect,
 		SubsecondPrecision: testSubsecondPrecision,
 		Tag:                testTag,
+		BufferLimit:        testBufferLimit,
 	}
 )
 
@@ -43,6 +45,7 @@ func TestGetFluentdConfig(t *testing.T) {
 		AsyncConnectKey:       testAsyncConnect,
 		SubsecondPrecisionKey: testSubsecondPrecision,
 		tagKey:                testTag,
+		BufferLimitKey:        testBufferLimit,
 	}
 
 	config := getFluentdConfig(args)


### PR DESCRIPTION
*Issue #, if available:*
Provide an entry to configure `fluentd-buffer-limit` in FireLens.
This is being enabled to resolve the following request: https://github.com/aws/containers-roadmap/issues/964

*Description of changes:*
Help to configure buffer limit size in fluentD Log Driver

*Testing:*
Check the code with `make test` and `make lint`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
