### PR TITLE
adding build-windows Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ SOURCEDIR=./
 
 AWS_CONTAINERD_LOGGERS_DIR=$(SOURCEDIR)
 AWS_CONTAINERD_LOGGERS_BINARY=$(ROOT)/bin/shim-loggers-for-containerd
+AWS_CONTAINERD_LOGGERS_BINARY_WINDOWS=$(ROOT)/bin/shim-loggers-for-containerd.exe
 SOURCES=$(shell find $(SOURCEDIR) -name '*.go')
 
 BINPATH:=$(abspath ./bin)
@@ -30,6 +31,9 @@ build: $(AWS_CONTAINERD_LOGGERS_BINARY)
 
 $(AWS_CONTAINERD_LOGGERS_BINARY):
 	go build -o $(AWS_CONTAINERD_LOGGERS_BINARY) $(AWS_CONTAINERD_LOGGERS_DIR)
+
+build-windows:
+	GOOS=windows go build -o $(AWS_CONTAINERD_LOGGERS_BINARY_WINDOWS) $(AWS_CONTAINERD_LOGGERS_DIR)
 
 test: $(SOURCES)
 	go test -tags unit -race -timeout 30s -cover $(shell go list ./...) --count=1


### PR DESCRIPTION
*Description of changes:*
Adding a `build-windows` Makefile target.

*Testing*
`make build-windows`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
