### PR TITLE
Change the maximum number of bytes included in a CloudWatch event.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,10 @@ require (
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
 	github.com/containerd/containerd v1.5.0
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
-	github.com/docker/docker v0.7.3-0.20190918143018-ad1b781e44fa
+	github.com/docker/docker v20.10.13+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0
-	github.com/fluent/fluent-logger-golang v1.4.0 // indirect
+	github.com/fluent/fluent-logger-golang v1.9.0 // indirect
 	github.com/golang/mock v1.4.1
 	github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
@@ -21,8 +21,5 @@ require (
 	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	gotest.tools v2.2.0+incompatible
 )
-
-// Workaround for optionally calling create log stream API
-replace github.com/docker/docker v0.7.3-0.20190918143018-ad1b781e44fa => github.com/xia-wu/moby v17.12.0-ce-rc1.0.20210308205136-2cd0a2a46d81+incompatible
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -227,6 +227,8 @@ github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TT
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/docker v20.10.13+incompatible h1:5s7uxnKZG+b8hYWlPYUi6x1Sjpq2MSt96d15eLZeHyw=
+github.com/docker/docker v20.10.13+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-events v0.0.0-20170721190031-9461782956ad/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
@@ -252,6 +254,8 @@ github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fluent/fluent-logger-golang v1.4.0 h1:uT1Lzz5yFV16YvDwWbjX6s3AYngnJz8byTCsMTIS0tU=
 github.com/fluent/fluent-logger-golang v1.4.0/go.mod h1:2/HCT/jTy78yGyeNGQLGQsjF3zzzAuy6Xlk6FCMV5eU=
+github.com/fluent/fluent-logger-golang v1.9.0 h1:zUdY44CHX2oIUc7VTNZc+4m+ORuO/mldQDA7czhWXEg=
+github.com/fluent/fluent-logger-golang v1.9.0/go.mod h1:2/HCT/jTy78yGyeNGQLGQsjF3zzzAuy6Xlk6FCMV5eU=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/logger/awslogs/logger.go
+++ b/logger/awslogs/logger.go
@@ -41,6 +41,10 @@ const (
 	// The value of maximumBytesPerEvent is adopted from Docker. Reference:
 	// https://github.com/moby/moby/blob/19.03/daemon/logger/awslogs/cloudwatchlogs.go#L58
 	maximumBytesPerEvent = 262144 - perEventBytes
+
+	// The max size of CloudWatch events is 256kb.
+	defaultAwsBufSizeInBytes = 256 * 1024
+
 )
 
 // Args represents AWSlogs driver arguments
@@ -103,7 +107,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 	if la.globalArgs.Mode == logger.NonBlockingMode {
 		debug.SendEventsToLog(logger.DaemonName, "Starting log streaming for non-blocking mode awslogs driver",
 			debug.INFO, 0)
-		l = logger.NewBufferedLogger(l, la.globalArgs.MaxBufferSize, la.globalArgs.ContainerID)
+		l = logger.NewBufferedLogger(l, defaultAwsBufSizeInBytes, la.globalArgs.MaxBufferSize, la.globalArgs.ContainerID)
 	}
 
 	// Start awslogs driver

--- a/logger/common.go
+++ b/logger/common.go
@@ -43,11 +43,11 @@ const (
 	// https://github.com/moby/moby/blob/19.03/daemon/logger/copier.go#L17
 	defaultMaxReadBytes = 2 * 1024
 
-	// defaultBufSizeInBytes provides a reasonable default for loggers that do
+	// DefaultBufSizeInBytes provides a reasonable default for loggers that do
 	// not have an external limit to impose on log line size. Adopted this value
 	// from Docker, reference:
 	// https://github.com/moby/moby/blob/19.03/daemon/logger/copier.go#L21
-	defaultBufSizeInBytes = 16 * 1024
+	DefaultBufSizeInBytes = 16 * 1024
 )
 
 type GlobalArgs struct {
@@ -117,7 +117,7 @@ type LogDriver interface {
 func NewLogger(options ...LoggerOpt) (LogDriver, error) {
 	l := &Logger{
 		Info:              &dockerlogger.Info{},
-		bufferSizeInBytes: defaultBufSizeInBytes,
+		bufferSizeInBytes: DefaultBufSizeInBytes,
 		maxReadBytes:      defaultMaxReadBytes,
 	}
 	for _, opt := range options {

--- a/logger/fluentd/logger.go
+++ b/logger/fluentd/logger.go
@@ -88,7 +88,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 
 	if la.globalArgs.Mode == logger.NonBlockingMode {
 		debug.SendEventsToLog(logger.DaemonName, "Starting non-blocking mode driver", debug.INFO, 0)
-		l = logger.NewBufferedLogger(l, la.globalArgs.MaxBufferSize, la.globalArgs.ContainerID)
+		l = logger.NewBufferedLogger(l, logger.DefaultBufSizeInBytes, la.globalArgs.MaxBufferSize, la.globalArgs.ContainerID)
 	}
 
 	// Start fluentd driver

--- a/logger/splunk/logger.go
+++ b/logger/splunk/logger.go
@@ -122,7 +122,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 
 	if la.globalArgs.Mode == logger.NonBlockingMode {
 		debug.SendEventsToLog(logger.DaemonName, "Starting non-blocking mode driver", debug.INFO, 0)
-		l = logger.NewBufferedLogger(l, la.globalArgs.MaxBufferSize, la.globalArgs.ContainerID)
+		l = logger.NewBufferedLogger(l, logger.DefaultBufSizeInBytes, la.globalArgs.MaxBufferSize, la.globalArgs.ContainerID)
 	}
 
 	// Start splunk log driver


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* This change increases the number of bytes sent to CloudWatch from 16kb
to 256kb in the awslogs driver. This change also includes updates to the docker and fluent-logger-golang dependencies.

This change was tested by building the shim-logger and verifying that the resulting logs were split up into 256kb chunks from the AWS console. Existing unit tests were also ran to verify this change does not introduce any regressions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
