### PR TITLE
Update golangci-lint-action to 3.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
           version: v1.33
       - uses: actions/setup-go@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3.1.0
         with:
           version: v1.33
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - name: build


### PR DESCRIPTION
The golangci-lint-action in the GitHub actions was failing because it
was auto-updating go to the latest version (1.18). Version 3 does not
re-install Go, instead it uses the currently installed version which
works with the github action.

*Issue #, if available:*

*Description of changes:*
- The golangci-lint-action was upgraded from v2 to v3.1.0.
- The setup-go-action was upgraded from v1 to v3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
