### PR TITLE
Patch docker stable release with an option to skip create log stream for awslogs driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,4 +22,6 @@ require (
 	gotest.tools v2.2.0+incompatible
 )
 
+replace github.com/docker/docker v20.10.13+incompatible => github.com/dharmadheeraj/moby v20.10.14-0.20220615184823-6b50baca60ea+incompatible
+
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8l
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/dharmadheeraj/moby v20.10.14-0.20220615184823-6b50baca60ea+incompatible h1:1skA277zj9p8Y5CE0UwIy61wMYzhSPjIfXEkKhkbciE=
+github.com/dharmadheeraj/moby v20.10.14-0.20220615184823-6b50baca60ea+incompatible/go.mod h1:ieBTs/KYEiTthOz9KWpwyVGVqeAtmCRkPejMkdQv1bA=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/distribution v0.0.0-20190905152932-14b96e55d84c/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.1-0.20190205005809-0d3efadf0154+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In one of the recents commits we updated the docker package to 20.10.13. But the commit to skip create log streams for aws log driver was not included in that tag of docker. 

This change will patch docker 20.10.13 with the missed commit. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
