### PR TITLE
Remove direct dependency on github.com/pkg/errors

### DIFF
--- a/debug/debug_linux.go
+++ b/debug/debug_linux.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -16,6 +17,7 @@
 package debug
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -24,15 +26,14 @@ import (
 	"time"
 
 	"github.com/coreos/go-systemd/journal"
-	"github.com/pkg/errors"
 )
 
 var (
 	// journalPriority is a map that maps strings to journal priority values
 	journalPriority = map[string]journal.Priority{
-		ERROR	  :	journal.PriErr,
-		INFO	  :	journal.PriInfo,
-		DEBUG	  :	journal.PriDebug,
+		ERROR: journal.PriErr,
+		INFO:  journal.PriInfo,
+		DEBUG: journal.PriDebug,
 	}
 )
 
@@ -76,6 +77,6 @@ func sendEventsToJournal(syslogIdentifier string, msg string, msgType journal.Pr
 
 // SetLogFilePath only supported on Windows
 // For non-Windows logs will be written to journald
-func SetLogFilePath(logFlag, cId string) error{
+func SetLogFilePath(logFlag, cId string) error {
 	return errors.New("debugging to file not supported, debug logs will be written with journald")
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/docker/docker v20.10.13+incompatible
 	github.com/docker/go-units v0.4.0
 	github.com/golang/mock v1.4.1
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.7.0
@@ -45,6 +44,7 @@ require (
 	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pelletier/go-toml v1.8.1 // indirect
 	github.com/philhofer/fwd v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.7.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/logger/awslogs/logger.go
+++ b/logger/awslogs/logger.go
@@ -15,13 +15,13 @@ package awslogs
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/shim-loggers-for-containerd/debug"
 	"github.com/aws/shim-loggers-for-containerd/logger"
 
 	"github.com/containerd/containerd/runtime/v2/logging"
 	dockerawslogs "github.com/docker/docker/daemon/logger/awslogs"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -89,7 +89,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 	)
 	stream, err := dockerawslogs.New(*info)
 	if err != nil {
-		debug.LoggerErr = errors.Wrap(err, "unable to create stream")
+		debug.LoggerErr = fmt.Errorf("unable to create stream: %w", err)
 		return debug.LoggerErr
 	}
 
@@ -101,7 +101,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 		logger.WithBufferSizeInBytes(maximumBytesPerEvent),
 	)
 	if err != nil {
-		debug.LoggerErr = errors.Wrap(err, "unable to create awslogs driver")
+		debug.LoggerErr = fmt.Errorf("unable to create awslogs driver: %w", err)
 		return debug.LoggerErr
 	}
 
@@ -115,7 +115,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 	debug.SendEventsToLog(logger.DaemonName, "Starting log streaming for awslogs driver", debug.INFO, 0)
 	err = l.Start(ctx, la.globalArgs.UID, la.globalArgs.GID, la.globalArgs.CleanupTime, ready)
 	if err != nil {
-		debug.LoggerErr = errors.Wrap(err, "failed to run awslogs driver")
+		debug.LoggerErr = fmt.Errorf("failed to run awslogs driver: %w", err)
 		// Do not return error if log driver has issue sending logs to destination, because if error
 		// returned here, containerd will identify this error and kill shim process, which will kill
 		// the container process accordingly.

--- a/logger/common_linux.go
+++ b/logger/common_linux.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
@@ -20,8 +21,6 @@ import (
 	"syscall"
 
 	"github.com/aws/shim-loggers-for-containerd/debug"
-
-	"github.com/pkg/errors"
 )
 
 // setUID sets UID of current goroutine/process.
@@ -31,13 +30,13 @@ import (
 func setUID(id int) error {
 	err := syscall.Setuid(id)
 	if err != nil {
-		return errors.Wrap(err, "unable to set uid")
+		return fmt.Errorf("unable to set uid: %w", err)
 	}
 
 	// Check if uid set correctly
 	u := syscall.Getuid()
 	if u != id {
-		return errors.New(fmt.Sprintf("want uid %d, but get uid %d", id, u))
+		return fmt.Errorf("want uid %d, but get uid %d", id, u)
 	}
 	debug.SendEventsToLog(DaemonName,
 		fmt.Sprintf("Set uid: %d", u),
@@ -53,13 +52,13 @@ func setUID(id int) error {
 func setGID(id int) error {
 	err := syscall.Setgid(id)
 	if err != nil {
-		return errors.Wrap(err, "unable to set gid")
+		return fmt.Errorf("unable to set gid: %w", err)
 	}
 
 	// Check if gid set correctly
 	g := syscall.Getgid()
 	if g != id {
-		return errors.New(fmt.Sprintf("want gid %d, but get gid %d", id, g))
+		return fmt.Errorf("want gid %d, but get gid %d", id, g)
 	}
 	debug.SendEventsToLog(DaemonName,
 		fmt.Sprintf("Set gid %d", g),

--- a/logger/common_test.go
+++ b/logger/common_test.go
@@ -21,12 +21,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	dockerlogger "github.com/docker/docker/daemon/logger"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
@@ -66,8 +66,7 @@ func (d *dummyClient) Log(msg *dockerlogger.Message) error {
 	}
 	f, err := os.OpenFile(logDestinationFileName, os.O_APPEND|os.O_RDWR, 0644)
 	if err != nil {
-		return errors.Wrapf(err,
-			"unable to open file %s to record log message", logDestinationFileName)
+		return fmt.Errorf("unable to open file %s to record log message: %w", logDestinationFileName, err)
 	}
 	defer f.Close()
 	b, err = json.Marshal(msg)

--- a/logger/fluentd/logger.go
+++ b/logger/fluentd/logger.go
@@ -15,13 +15,13 @@ package fluentd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/shim-loggers-for-containerd/debug"
 	"github.com/aws/shim-loggers-for-containerd/logger"
 
 	"github.com/containerd/containerd/runtime/v2/logging"
 	dockerfluentd "github.com/docker/docker/daemon/logger/fluentd"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -71,7 +71,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 	)
 	stream, err := dockerfluentd.New(*info)
 	if err != nil {
-		debug.LoggerErr = errors.Wrap(err, "unable to create stream")
+		debug.LoggerErr = fmt.Errorf("unable to create stream: %w", err)
 		return debug.LoggerErr
 	}
 
@@ -82,7 +82,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 		logger.WithStream(stream),
 	)
 	if err != nil {
-		debug.LoggerErr = errors.Wrap(err, "unable to create fluentd driver")
+		debug.LoggerErr = fmt.Errorf("unable to create fluentd driver: %w", err)
 		return debug.LoggerErr
 	}
 
@@ -95,7 +95,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 	debug.SendEventsToLog(logger.DaemonName, "Starting fluentd driver", debug.INFO, 0)
 	err = l.Start(ctx, la.globalArgs.UID, la.globalArgs.GID, la.globalArgs.CleanupTime, ready)
 	if err != nil {
-		debug.LoggerErr = errors.Wrap(err, "failed to run fluentd driver")
+		debug.LoggerErr = fmt.Errorf("failed to run fluentd driver: %w", err)
 		// Do not return error if log driver has issue sending logs to destination, because if error
 		// returned here, containerd will identify this error and kill shim process, which will kill
 		// the container process accordingly.

--- a/logger/splunk/logger.go
+++ b/logger/splunk/logger.go
@@ -15,10 +15,10 @@ package splunk
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/containerd/containerd/runtime/v2/logging"
 	dockersplunk "github.com/docker/docker/daemon/logger/splunk"
-	"github.com/pkg/errors"
 
 	"github.com/aws/shim-loggers-for-containerd/debug"
 	"github.com/aws/shim-loggers-for-containerd/logger"
@@ -105,7 +105,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 
 	stream, err := dockersplunk.New(*info)
 	if err != nil {
-		debug.LoggerErr = errors.Wrap(err, "unable to create stream")
+		debug.LoggerErr = fmt.Errorf("unable to create stream: %w", err)
 		return debug.LoggerErr
 	}
 
@@ -116,7 +116,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 		logger.WithStream(stream),
 	)
 	if err != nil {
-		debug.LoggerErr = errors.Wrap(err, "unable to create splunk log driver")
+		debug.LoggerErr = fmt.Errorf("unable to create splunk log driver: %w", err)
 		return debug.LoggerErr
 	}
 
@@ -129,7 +129,7 @@ func (la *LoggerArgs) RunLogDriver(ctx context.Context, config *logging.Config, 
 	debug.SendEventsToLog(logger.DaemonName, "Starting splunk driver", debug.INFO, 0)
 	err = l.Start(ctx, la.globalArgs.UID, la.globalArgs.GID, la.globalArgs.CleanupTime, ready)
 	if err != nil {
-		debug.LoggerErr = errors.Wrap(err, "failed to run splunk driver")
+		debug.LoggerErr = fmt.Errorf("failed to run splunk driver: %w", err)
 		// Do not return error if log driver has issue sending logs to destination, because if error
 		// returned here, containerd will identify this error and kill shim process, which will kill
 		// the container process accordingly.


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

*Issue #, if available:* #31

*Description of changes:*
Removes direct dependency on github.com/pkg/errors and replaces functionality with built-in standard library usage of errors and fmt packages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
