### PR TITLE
Allow to configure the endpoint for awslog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 bin/
 .idea/
+deps/
+
+.get-deps-stamp

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ lint: $(SOURCES)
 
 .get-deps-stamp:
 	GO111MODULE=off GOBIN=$(DEPSPATH) go get golang.org/x/tools/cmd/goimports
-	GOBIN=$(DEPSPATH) go get github.com/golang/mock/mockgen@v1.3.1
+	GOBIN=$(DEPSPATH) go get github.com/golang/mock/mockgen@v1.4.1
 	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(DEPSPATH) v1.21.0
 	$(DEPSPATH)/golangci-lint --version
 	touch .get-deps-stamp

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The following additional arguments are supported for the `awslogs` shim logger b
 | awslogs-create-stream | No | Set to `true` by default. The log stream will always be created unless this value specified to `false` explicitly.|
 | awslogs-multiline-pattern | No | Matches the behavior of the [`awslogs` Docker log driver](https://docs.docker.com/config/containers/logging/awslogs/#amazon-cloudwatch-logs-options#awslogs-multiline-pattern).|
 | awslogs-datetime-format | No | Matches the behavior of the [`awslogs` Docker log driver](https://docs.docker.com/config/containers/logging/awslogs/#amazon-cloudwatch-logs-options#awslogs-datetime-format)|
+| awslogs-endpoint | No | Matches the behavior of the [`awslogs` Docker log driver](https://docs.docker.com/config/containers/logging/awslogs/#awslogs-endpoint)|
 
 #### Splunk
 The following additional arguments are supported for the `splunk` shim logger binary, which can be used to send container logs to [splunk](https://www.splunk.com/en_us/central-log-management.html).

--- a/args.go
+++ b/args.go
@@ -160,6 +160,7 @@ func getAWSLogsArgs() (*awslogs.Args, error) {
 		CreateStream:        viper.GetString(awslogs.CreateStreamKey),
 		MultilinePattern:    viper.GetString(awslogs.MultilinePatternKey),
 		DatetimeFormat:      viper.GetString(awslogs.DatetimeFormatKey),
+		Endpoint:            viper.GetString(awslogs.EndpointKey),
 	}, nil
 }
 

--- a/init.go
+++ b/init.go
@@ -14,10 +14,11 @@
 package main
 
 import (
+	"github.com/spf13/pflag"
+
 	"github.com/aws/shim-loggers-for-containerd/logger/awslogs"
 	"github.com/aws/shim-loggers-for-containerd/logger/fluentd"
 	"github.com/aws/shim-loggers-for-containerd/logger/splunk"
-	"github.com/spf13/pflag"
 )
 
 const (
@@ -106,6 +107,7 @@ func initAWSLogsOpts() {
 	pflag.String(awslogs.CredentialsEndpointKey, "", "The endpoint for iam credentials")
 	pflag.String(awslogs.MultilinePatternKey, "", "Support multiline pattern for debug")
 	pflag.String(awslogs.DatetimeFormatKey, "", "Multiline pattern in strftime format")
+	pflag.String(awslogs.EndpointKey, "", "The CloudWatch endpoint to use")
 }
 
 // initFluentdOpts initialize fluentd driver specified options

--- a/logger/awslogs/logger.go
+++ b/logger/awslogs/logger.go
@@ -34,6 +34,7 @@ const (
 	MultilinePatternKey    = "awslogs-multiline-pattern"
 	DatetimeFormatKey      = "awslogs-datetime-format"
 	CredentialsEndpointKey = "awslogs-credentials-endpoint"
+	EndpointKey            = "awslogs-endpoint"
 
 	// There are 26 bytes additional bytes for each log event:
 	// See more details in: http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
@@ -44,7 +45,6 @@ const (
 
 	// The max size of CloudWatch events is 256kb.
 	defaultAwsBufSizeInBytes = 256 * 1024
-
 )
 
 // Args represents AWSlogs driver arguments
@@ -60,6 +60,7 @@ type Args struct {
 	CreateStream     string
 	MultilinePattern string
 	DatetimeFormat   string
+	Endpoint         string
 }
 
 // LoggerArgs stores global logger args and awslogs specific args
@@ -151,6 +152,10 @@ func getAWSLogsConfig(args *Args) map[string]string {
 	datetimeFormat := args.DatetimeFormat
 	if datetimeFormat != "" {
 		config[DatetimeFormatKey] = datetimeFormat
+	}
+	endpoint := args.Endpoint
+	if endpoint != "" {
+		config[EndpointKey] = endpoint
 	}
 
 	return config

--- a/logger/awslogs/logger_test.go
+++ b/logger/awslogs/logger_test.go
@@ -11,6 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
+//go:build unit
 // +build unit
 
 package awslogs
@@ -30,6 +31,7 @@ const (
 	testCreateStream        = "true"
 	testMultilinePattern    = "test-multiline-pattern"
 	testDatetimeFormat      = "test-datetime-format"
+	testEndpoint            = "test-endpoint"
 )
 
 var (
@@ -42,6 +44,7 @@ var (
 		CreateStream:        testCreateStream,
 		MultilinePattern:    testMultilinePattern,
 		DatetimeFormat:      testDatetimeFormat,
+		Endpoint:            testEndpoint,
 	}
 )
 
@@ -57,6 +60,7 @@ func TestGetAWSLogsConfig(t *testing.T) {
 		CreateStreamKey:        testCreateStream,
 		MultilinePatternKey:    testMultilinePattern,
 		DatetimeFormatKey:      testDatetimeFormat,
+		EndpointKey:            testEndpoint,
 	}
 
 	config := getAWSLogsConfig(args)


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
With this change, the shim logger can support to specify the endpoint for the aws logs.

Builds successfully and all tests pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
