### PR TITLE
Update GitHub Actions CI to address updates and issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.17', '1.18', '1.19' ]
+        go: [ '1.17', '1.18', '1.19', '1.20' ]
         os: [ ubuntu-22.04, windows-2022 ]
     name: ${{ matrix.os }} / Go ${{ matrix.go }}
     steps:
@@ -14,7 +14,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.3.0
         with:
-          version: v1.50.1
+          version: v1.52.2
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.3.0
         with:
           version: v1.52.2
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '1.20'
       
   build:
     strategy:
@@ -31,9 +32,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
+          cache: false
       - name: build
         run: make build
       - name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,36 @@
+name: CI
 on: [push, pull_request]
 
 jobs:
-  build:
-    runs-on: ubuntu-22.04
+  lint:
     strategy:
       fail-fast: false
       matrix:
-        go: [ '1.17', '1.18', '1.19', '1.20' ]
-        os: [ ubuntu-22.04, windows-2022 ]
-    name: ${{ matrix.os }} / Go ${{ matrix.go }}
+        os: [ 'ubuntu-22.04' ]
+
+    name: ${{ matrix.os }} / Lint
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.3.0
         with:
           version: v1.52.2
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.20'
+      
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        go: [ '1.17', '1.18', '1.19', '1.20' ]
+        os: [ 'ubuntu-22.04', 'windows-2022' ]
+
+    name: ${{ matrix.os }} / Go ${{ matrix.go }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 bin/
 .idea/
 deps/
-
 .get-deps-stamp

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ lint: $(SOURCES)
 .get-deps-stamp:
 	GO111MODULE=off GOBIN=$(DEPSPATH) go get golang.org/x/tools/cmd/goimports
 	GOBIN=$(DEPSPATH) go get github.com/golang/mock/mockgen@v1.4.1
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(DEPSPATH) v1.21.0
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(DEPSPATH) v1.52.2
 	$(DEPSPATH)/golangci-lint --version
 	touch .get-deps-stamp
 


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

*Issue #, if available:*
N/A

*Description of changes:*

1. Adds Go 1.20 support.
2. Fixes an issue where Windows platform was not being tested.
3. Updates the GitHub actions/setup-go package and configures it before lint run so the appropriate version of Go is used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
